### PR TITLE
feat: assets management, net worth page, and display currency

### DIFF
--- a/app/api/assets/[id]/refresh-price/route.ts
+++ b/app/api/assets/[id]/refresh-price/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/app/lib/db";
+import { getSession } from "@/app/lib/auth";
+import { getOwnedAsset } from "../../asset-route-utils";
+
+async function fetchStockPrice(ticker: string): Promise<number> {
+  const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(ticker)}?interval=1d&range=1d`;
+  const res = await fetch(url, { headers: { "User-Agent": "Mozilla/5.0" }, cache: "no-store" });
+  if (!res.ok) throw new Error(`Yahoo Finance returned ${res.status} for ticker ${ticker}`);
+  const json = await res.json();
+  const price = json?.chart?.result?.[0]?.meta?.regularMarketPrice;
+  if (!price) throw new Error(`Could not parse price for ticker ${ticker}`);
+  return price;
+}
+
+async function fetchGoldPriceUsd(): Promise<number> {
+  const res = await fetch("https://open.er-api.com/v6/latest/XAU", { cache: "no-store" });
+  if (!res.ok) throw new Error(`Gold price fetch returned ${res.status}`);
+  const json = await res.json();
+  const usdPerOz = json?.rates?.USD;
+  if (!usdPerOz) throw new Error("Could not parse gold price");
+  return usdPerOz;
+}
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getSession(req);
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+  const asset = await getOwnedAsset(id, session.userId);
+  if (!asset) return NextResponse.json({ error: "Asset not found" }, { status: 404 });
+
+  if (asset.type !== "stock" && asset.type !== "gold") {
+    return NextResponse.json({ error: "Price refresh is only supported for stocks and gold" }, { status: 400 });
+  }
+
+  try {
+    let pricePerUnit: number;
+    if (asset.type === "stock") {
+      if (!asset.ticker) return NextResponse.json({ error: "Asset has no ticker" }, { status: 400 });
+      pricePerUnit = await fetchStockPrice(asset.ticker);
+    } else {
+      pricePerUnit = await fetchGoldPriceUsd();
+    }
+
+    const quantity = asset.quantity ?? 1;
+    const currentValue = pricePerUnit * quantity;
+
+    const updated = await prisma.asset.update({
+      where: { id },
+      data: { currentValue, lastPricedAt: new Date() },
+    });
+    return NextResponse.json(updated);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Price fetch failed";
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/app/api/assets/[id]/refresh-price/route.ts
+++ b/app/api/assets/[id]/refresh-price/route.ts
@@ -5,7 +5,14 @@ import { getOwnedAsset } from "../../asset-route-utils";
 
 async function fetchStockPrice(ticker: string): Promise<number> {
   const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(ticker)}?interval=1d&range=1d`;
-  const res = await fetch(url, { headers: { "User-Agent": "Mozilla/5.0" }, cache: "no-store" });
+  const res = await fetch(url, {
+    headers: {
+      "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+      "Accept": "application/json",
+      "Accept-Language": "en-US,en;q=0.9",
+    },
+    cache: "no-store",
+  });
   if (!res.ok) throw new Error(`Yahoo Finance returned ${res.status} for ticker ${ticker}`);
   const json = await res.json();
   const price = json?.chart?.result?.[0]?.meta?.regularMarketPrice;

--- a/app/api/assets/[id]/route.ts
+++ b/app/api/assets/[id]/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/app/lib/db";
+import { getSession } from "@/app/lib/auth";
+import { getOwnedAsset, parseAssetPayload, AssetPayload } from "../asset-route-utils";
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getSession(req);
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+  const asset = await getOwnedAsset(id, session.userId);
+  if (!asset) return NextResponse.json({ error: "Asset not found" }, { status: 404 });
+
+  return NextResponse.json(asset);
+}
+
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getSession(req);
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+  const existing = await getOwnedAsset(id, session.userId);
+  if (!existing) return NextResponse.json({ error: "Asset not found" }, { status: 404 });
+
+  try {
+    const parsed = parseAssetPayload(await req.json() as AssetPayload);
+    const updated = await prisma.asset.update({ where: { id }, data: parsed });
+    return NextResponse.json(updated);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unable to update asset";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getSession(req);
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+  const asset = await getOwnedAsset(id, session.userId);
+  if (!asset) return NextResponse.json({ error: "Asset not found" }, { status: 404 });
+
+  await prisma.asset.delete({ where: { id } });
+  return NextResponse.json({ success: true });
+}

--- a/app/api/assets/asset-route-utils.ts
+++ b/app/api/assets/asset-route-utils.ts
@@ -1,4 +1,4 @@
-import { AssetType, Currency } from "@prisma/client";
+import { AssetType, Currency, Prisma } from "@prisma/client";
 import { prisma } from "@/app/lib/db";
 
 const ASSET_TYPES = new Set<AssetType>(["real_estate", "stock", "bond", "gold"]);
@@ -36,7 +36,7 @@ export function parseAssetPayload(payload: AssetPayload) {
     currentValue,
     quantity: payload.quantity != null ? Number(payload.quantity) : null,
     ticker: payload.ticker?.trim() || null,
-    metadata: payload.metadata ?? {},
+    metadata: (payload.metadata ?? {}) as Prisma.InputJsonValue,
   };
 }
 

--- a/app/api/assets/asset-route-utils.ts
+++ b/app/api/assets/asset-route-utils.ts
@@ -1,0 +1,45 @@
+import { AssetType, Currency } from "@prisma/client";
+import { prisma } from "@/app/lib/db";
+
+const ASSET_TYPES = new Set<AssetType>(["real_estate", "stock", "bond", "gold"]);
+const CURRENCIES = new Set<Currency>(["USD", "VND"]);
+
+export interface AssetPayload {
+  name: string;
+  type: string;
+  currency?: string;
+  currentValue: number;
+  quantity?: number | null;
+  ticker?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export function parseAssetPayload(payload: AssetPayload) {
+  const name = payload.name?.trim();
+  if (!name) throw new Error("Name is required");
+  if (!ASSET_TYPES.has(payload.type as AssetType)) throw new Error("Invalid asset type");
+  const currency = (payload.currency ?? "USD") as Currency;
+  if (!CURRENCIES.has(currency)) throw new Error("Invalid currency");
+  const currentValue = Number(payload.currentValue);
+  if (!Number.isFinite(currentValue) || currentValue < 0) throw new Error("Current value must be a non-negative number");
+  if (payload.type === "stock") {
+    if (!payload.ticker?.trim()) throw new Error("Ticker is required for stocks");
+    if (!payload.quantity || Number(payload.quantity) <= 0) throw new Error("Quantity must be positive for stocks");
+  }
+  if (payload.type === "gold") {
+    if (!payload.quantity || Number(payload.quantity) <= 0) throw new Error("Quantity must be positive for gold");
+  }
+  return {
+    name,
+    type: payload.type as AssetType,
+    currency,
+    currentValue,
+    quantity: payload.quantity != null ? Number(payload.quantity) : null,
+    ticker: payload.ticker?.trim() || null,
+    metadata: payload.metadata ?? {},
+  };
+}
+
+export async function getOwnedAsset(id: string, userId: string) {
+  return prisma.asset.findFirst({ where: { id, userId } });
+}

--- a/app/api/assets/route.ts
+++ b/app/api/assets/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/app/lib/db";
+import { getSession } from "@/app/lib/auth";
+import { parseAssetPayload, AssetPayload } from "./asset-route-utils";
+
+export async function GET(req: NextRequest) {
+  const session = await getSession(req);
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const assets = await prisma.asset.findMany({
+    where: { userId: session.userId },
+    orderBy: [{ type: "asc" }, { createdAt: "desc" }],
+  });
+
+  return NextResponse.json(assets);
+}
+
+export async function POST(req: NextRequest) {
+  const session = await getSession(req);
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  try {
+    const parsed = parseAssetPayload(await req.json() as AssetPayload);
+    const asset = await prisma.asset.create({
+      data: { ...parsed, userId: session.userId },
+    });
+    return NextResponse.json(asset, { status: 201 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unable to create asset";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/app/api/networth/route.ts
+++ b/app/api/networth/route.ts
@@ -3,15 +3,16 @@ import { prisma } from "@/app/lib/db";
 import { getSession } from "@/app/lib/auth";
 import { Currency } from "@prisma/client";
 
-function convertToUsd(
+function convertToCurrency(
   amount: number,
-  currency: Currency,
+  fromCurrency: Currency,
+  toCurrency: Currency,
   rates: { fromCurrency: string; toCurrency: string; rate: number }[]
 ): number {
-  if (currency === "USD") return amount;
-  const direct = rates.find(r => r.fromCurrency === currency && r.toCurrency === "USD");
+  if (fromCurrency === toCurrency) return amount;
+  const direct = rates.find(r => r.fromCurrency === fromCurrency && r.toCurrency === toCurrency);
   if (direct) return amount * direct.rate;
-  const inverse = rates.find(r => r.fromCurrency === "USD" && r.toCurrency === currency);
+  const inverse = rates.find(r => r.fromCurrency === toCurrency && r.toCurrency === fromCurrency);
   if (inverse) return amount / inverse.rate;
   return amount;
 }
@@ -20,7 +21,12 @@ export async function GET(req: NextRequest) {
   const session = await getSession(req);
   if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const [accounts, assets, loans, exchangeRates] = await Promise.all([
+  const [settings, accounts, assets, loans, exchangeRates] = await Promise.all([
+    prisma.userSettings.upsert({
+      where: { userId: session.userId },
+      create: { userId: session.userId },
+      update: {},
+    }),
     prisma.account.findMany({ where: { userId: session.userId } }),
     prisma.asset.findMany({ where: { userId: session.userId } }),
     prisma.loan.findMany({
@@ -37,51 +43,68 @@ export async function GET(req: NextRequest) {
     prisma.exchangeRate.findMany({ where: { userId: session.userId } }),
   ]);
 
+  const targetCurrency = settings.defaultCurrency;
   const missingRates: string[] = [];
 
-  const accountItems = accounts.map(a => {
-    const valueInUsd = convertToUsd(a.balance, a.currency, exchangeRates);
-    if (a.currency !== "USD" && valueInUsd === a.balance) missingRates.push(`${a.currency}/USD`);
-    return { id: a.id, name: a.name, balance: a.balance, currency: a.currency, valueInUsd };
-  });
+  function convert(amount: number, fromCurrency: Currency): number {
+    const result = convertToCurrency(amount, fromCurrency, targetCurrency, exchangeRates);
+    if (fromCurrency !== targetCurrency && result === amount) {
+      missingRates.push(`${fromCurrency}/${targetCurrency}`);
+    }
+    return result;
+  }
 
-  const assetItems = assets.map(a => {
-    const valueInUsd = convertToUsd(a.currentValue, a.currency, exchangeRates);
-    if (a.currency !== "USD" && valueInUsd === a.currentValue) missingRates.push(`${a.currency}/USD`);
-    return { ...a, valueInUsd };
-  });
+  const accountItems = accounts.map(a => ({
+    id: a.id,
+    name: a.name,
+    balance: a.balance,
+    currency: a.currency,
+    valueInTarget: convert(a.balance, a.currency),
+  }));
+
+  const assetItems = assets.map(a => ({
+    ...a,
+    valueInTarget: convert(a.currentValue, a.currency),
+  }));
 
   const loanItems = loans.map(loan => {
     const principalAmount = loan.initialTransaction?.amount ?? 0;
     const paidPrincipal = loan.payments.reduce((sum, p) => sum + (p.principalTransaction?.amount ?? 0), 0);
     const outstandingPrincipal = Math.max(0, principalAmount - paidPrincipal);
-    const valueInUsd = convertToUsd(outstandingPrincipal, loan.currency, exchangeRates);
-    return { id: loan.id, name: loan.name, direction: loan.direction, outstandingPrincipal, currency: loan.currency, valueInUsd };
+    return {
+      id: loan.id,
+      name: loan.name,
+      direction: loan.direction,
+      outstandingPrincipal,
+      currency: loan.currency,
+      valueInTarget: convert(outstandingPrincipal, loan.currency),
+    };
   });
 
   const borrowedLoans = loanItems.filter(l => l.direction === "borrowed");
 
-  const liquidTotal = accountItems.reduce((s, a) => s + a.valueInUsd, 0);
+  const liquidTotal = accountItems.reduce((s, a) => s + a.valueInTarget, 0);
   const assetsByType = {
     real_estate: assetItems.filter(a => a.type === "real_estate"),
     stock: assetItems.filter(a => a.type === "stock"),
     bond: assetItems.filter(a => a.type === "bond"),
     gold: assetItems.filter(a => a.type === "gold"),
   };
-  const assetsTotal = assetItems.reduce((s, a) => s + a.valueInUsd, 0);
-  const liabilitiesTotal = borrowedLoans.reduce((s, l) => s + l.valueInUsd, 0);
+  const assetsTotal = assetItems.reduce((s, a) => s + a.valueInTarget, 0);
+  const liabilitiesTotal = borrowedLoans.reduce((s, l) => s + l.valueInTarget, 0);
 
   return NextResponse.json({
+    currency: targetCurrency,
     totalNetWorth: liquidTotal + assetsTotal - liabilitiesTotal,
     missingRates: [...new Set(missingRates)],
     liquid: { total: liquidTotal, accounts: accountItems },
     assets: {
       total: assetsTotal,
       byType: {
-        real_estate: { total: assetsByType.real_estate.reduce((s, a) => s + a.valueInUsd, 0), items: assetsByType.real_estate },
-        stock: { total: assetsByType.stock.reduce((s, a) => s + a.valueInUsd, 0), items: assetsByType.stock },
-        bond: { total: assetsByType.bond.reduce((s, a) => s + a.valueInUsd, 0), items: assetsByType.bond },
-        gold: { total: assetsByType.gold.reduce((s, a) => s + a.valueInUsd, 0), items: assetsByType.gold },
+        real_estate: { total: assetsByType.real_estate.reduce((s, a) => s + a.valueInTarget, 0), items: assetsByType.real_estate },
+        stock: { total: assetsByType.stock.reduce((s, a) => s + a.valueInTarget, 0), items: assetsByType.stock },
+        bond: { total: assetsByType.bond.reduce((s, a) => s + a.valueInTarget, 0), items: assetsByType.bond },
+        gold: { total: assetsByType.gold.reduce((s, a) => s + a.valueInTarget, 0), items: assetsByType.gold },
       },
     },
     liabilities: { total: liabilitiesTotal, loans: borrowedLoans },

--- a/app/api/networth/route.ts
+++ b/app/api/networth/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/app/lib/db";
+import { getSession } from "@/app/lib/auth";
+import { Currency } from "@prisma/client";
+
+function convertToUsd(
+  amount: number,
+  currency: Currency,
+  rates: { fromCurrency: string; toCurrency: string; rate: number }[]
+): number {
+  if (currency === "USD") return amount;
+  const direct = rates.find(r => r.fromCurrency === currency && r.toCurrency === "USD");
+  if (direct) return amount * direct.rate;
+  const inverse = rates.find(r => r.fromCurrency === "USD" && r.toCurrency === currency);
+  if (inverse) return amount / inverse.rate;
+  return amount;
+}
+
+export async function GET(req: NextRequest) {
+  const session = await getSession(req);
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const [accounts, assets, loans, exchangeRates] = await Promise.all([
+    prisma.account.findMany({ where: { userId: session.userId } }),
+    prisma.asset.findMany({ where: { userId: session.userId } }),
+    prisma.loan.findMany({
+      where: { userId: session.userId, status: "active" },
+      include: {
+        initialTransaction: { select: { amount: true } },
+        payments: {
+          include: {
+            principalTransaction: { select: { amount: true } },
+          },
+        },
+      },
+    }),
+    prisma.exchangeRate.findMany({ where: { userId: session.userId } }),
+  ]);
+
+  const missingRates: string[] = [];
+
+  const accountItems = accounts.map(a => {
+    const valueInUsd = convertToUsd(a.balance, a.currency, exchangeRates);
+    if (a.currency !== "USD" && valueInUsd === a.balance) missingRates.push(`${a.currency}/USD`);
+    return { id: a.id, name: a.name, balance: a.balance, currency: a.currency, valueInUsd };
+  });
+
+  const assetItems = assets.map(a => {
+    const valueInUsd = convertToUsd(a.currentValue, a.currency, exchangeRates);
+    if (a.currency !== "USD" && valueInUsd === a.currentValue) missingRates.push(`${a.currency}/USD`);
+    return { ...a, valueInUsd };
+  });
+
+  const loanItems = loans.map(loan => {
+    const principalAmount = loan.initialTransaction?.amount ?? 0;
+    const paidPrincipal = loan.payments.reduce((sum, p) => sum + (p.principalTransaction?.amount ?? 0), 0);
+    const outstandingPrincipal = Math.max(0, principalAmount - paidPrincipal);
+    const valueInUsd = convertToUsd(outstandingPrincipal, loan.currency, exchangeRates);
+    return { id: loan.id, name: loan.name, direction: loan.direction, outstandingPrincipal, currency: loan.currency, valueInUsd };
+  });
+
+  const borrowedLoans = loanItems.filter(l => l.direction === "borrowed");
+
+  const liquidTotal = accountItems.reduce((s, a) => s + a.valueInUsd, 0);
+  const assetsByType = {
+    real_estate: assetItems.filter(a => a.type === "real_estate"),
+    stock: assetItems.filter(a => a.type === "stock"),
+    bond: assetItems.filter(a => a.type === "bond"),
+    gold: assetItems.filter(a => a.type === "gold"),
+  };
+  const assetsTotal = assetItems.reduce((s, a) => s + a.valueInUsd, 0);
+  const liabilitiesTotal = borrowedLoans.reduce((s, l) => s + l.valueInUsd, 0);
+
+  return NextResponse.json({
+    totalNetWorth: liquidTotal + assetsTotal - liabilitiesTotal,
+    missingRates: [...new Set(missingRates)],
+    liquid: { total: liquidTotal, accounts: accountItems },
+    assets: {
+      total: assetsTotal,
+      byType: {
+        real_estate: { total: assetsByType.real_estate.reduce((s, a) => s + a.valueInUsd, 0), items: assetsByType.real_estate },
+        stock: { total: assetsByType.stock.reduce((s, a) => s + a.valueInUsd, 0), items: assetsByType.stock },
+        bond: { total: assetsByType.bond.reduce((s, a) => s + a.valueInUsd, 0), items: assetsByType.bond },
+        gold: { total: assetsByType.gold.reduce((s, a) => s + a.valueInUsd, 0), items: assetsByType.gold },
+      },
+    },
+    liabilities: { total: liabilitiesTotal, loans: borrowedLoans },
+  });
+}

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -22,6 +22,7 @@ export async function PUT(req: NextRequest) {
   const body = await req.json();
 
   const allowed = [
+    "defaultCurrency",
     "loanBorrowedInitialCategoryId",
     "loanBorrowedPrincipalCategoryId",
     "loanBorrowedInterestCategoryId",

--- a/app/assets/page.tsx
+++ b/app/assets/page.tsx
@@ -30,6 +30,7 @@ export default function AssetsPage() {
   const [formOpen, setFormOpen] = useState(false);
   const [editingAsset, setEditingAsset] = useState<Asset | null>(null);
   const [refreshingId, setRefreshingId] = useState<string | null>(null);
+  const [refreshError, setRefreshError] = useState<string | null>(null);
 
   const { data: assets = [], isLoading, error } = useQuery({
     queryKey: ["assets"],
@@ -47,9 +48,12 @@ export default function AssetsPage() {
 
   async function handleRefreshPrice(asset: Asset) {
     setRefreshingId(asset.id);
+    setRefreshError(null);
     try {
       await refreshAssetPrice(asset.id);
       invalidate();
+    } catch (e) {
+      setRefreshError(e instanceof Error ? e.message : "Failed to refresh price");
     } finally {
       setRefreshingId(null);
     }
@@ -80,6 +84,7 @@ export default function AssetsPage() {
 
       {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
       {!isLoading && error && <p className="text-sm text-destructive">Unable to load assets.</p>}
+      {refreshError && <p className="text-sm text-destructive mb-2">{refreshError}</p>}
 
       {!isLoading && !error && assets.length === 0 && (
         <div className="rounded-lg border p-4 space-y-1">

--- a/app/assets/page.tsx
+++ b/app/assets/page.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { AssetForm } from "@/components/assets/asset-form";
+import { AssetCard } from "@/components/assets/asset-card";
+import {
+  createAsset,
+  deleteAsset,
+  getAssets,
+  refreshAssetPrice,
+  updateAsset,
+  Asset,
+  AssetType,
+} from "@/lib/api/assets";
+import { formatCurrency } from "@/lib/utils";
+
+const TYPE_ORDER: AssetType[] = ["real_estate", "stock", "bond", "gold"];
+const TYPE_LABELS: Record<AssetType, string> = {
+  real_estate: "Real Estate",
+  stock: "Stocks",
+  bond: "Bonds",
+  gold: "Gold",
+};
+
+export default function AssetsPage() {
+  const queryClient = useQueryClient();
+  const [formOpen, setFormOpen] = useState(false);
+  const [editingAsset, setEditingAsset] = useState<Asset | null>(null);
+  const [refreshingId, setRefreshingId] = useState<string | null>(null);
+
+  const { data: assets = [], isLoading, error } = useQuery({
+    queryKey: ["assets"],
+    queryFn: getAssets,
+  });
+
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: ["assets"] });
+
+  const createMutation = useMutation({ mutationFn: createAsset, onSuccess: invalidate });
+  const updateMutation = useMutation({
+    mutationFn: ({ id, ...p }: { id: string } & Parameters<typeof updateAsset>[1]) => updateAsset(id, p),
+    onSuccess: invalidate,
+  });
+  const deleteMutation = useMutation({ mutationFn: deleteAsset, onSuccess: invalidate });
+
+  async function handleRefreshPrice(asset: Asset) {
+    setRefreshingId(asset.id);
+    try {
+      await refreshAssetPrice(asset.id);
+      invalidate();
+    } finally {
+      setRefreshingId(null);
+    }
+  }
+
+  const totalValue = assets.reduce((sum, a) => sum + a.currentValue, 0);
+
+  const byType = TYPE_ORDER.reduce((acc, t) => {
+    acc[t] = assets.filter(a => a.type === t);
+    return acc;
+  }, {} as Record<AssetType, Asset[]>);
+
+  return (
+    <main className="max-w-lg mx-auto px-4 py-8 pb-24">
+      <div className="mb-6 flex items-start justify-between">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-semibold">Assets</h1>
+          {assets.length > 0 && (
+            <p className="text-sm text-muted-foreground">
+              Total: {formatCurrency(totalValue, "USD")}
+            </p>
+          )}
+        </div>
+        <Button size="sm" onClick={() => { setEditingAsset(null); setFormOpen(true); }}>
+          <Plus className="size-4 mr-1" />Add Asset
+        </Button>
+      </div>
+
+      {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+      {!isLoading && error && <p className="text-sm text-destructive">Unable to load assets.</p>}
+
+      {!isLoading && !error && assets.length === 0 && (
+        <div className="rounded-lg border p-4 space-y-1">
+          <p className="text-sm font-medium">No assets yet</p>
+          <p className="text-sm text-muted-foreground">
+            Add real estate, stocks, bonds, or gold to track your wealth.
+          </p>
+        </div>
+      )}
+
+      {!isLoading && !error && assets.length > 0 && (
+        <div className="space-y-6">
+          {TYPE_ORDER.map(type => {
+            const items = byType[type];
+            if (items.length === 0) return null;
+            return (
+              <div key={type}>
+                <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+                  {TYPE_LABELS[type]}
+                </h2>
+                <div className="space-y-2">
+                  {items.map(asset => (
+                    <AssetCard
+                      key={asset.id}
+                      asset={asset}
+                      onEdit={a => { setEditingAsset(a); setFormOpen(true); }}
+                      onRefreshPrice={handleRefreshPrice}
+                      refreshing={refreshingId === asset.id}
+                    />
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <AssetForm
+        open={formOpen}
+        asset={editingAsset}
+        onClose={() => { setFormOpen(false); setEditingAsset(null); }}
+        onSubmit={async payload => {
+          if (editingAsset) {
+            await updateMutation.mutateAsync({ id: editingAsset.id, ...payload });
+          } else {
+            await createMutation.mutateAsync(payload);
+          }
+        }}
+        onDelete={async asset => { await deleteMutation.mutateAsync(asset.id); }}
+      />
+    </main>
+  );
+}

--- a/app/networth/page.tsx
+++ b/app/networth/page.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+import { AlertTriangle, ArrowRight } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  getNetWorth,
+  NetWorthResponse,
+  AssetItem,
+  AccountItem,
+  LoanItem,
+} from "@/lib/api/networth";
+import { formatCurrency } from "@/lib/utils";
+
+const ASSET_TYPE_LABELS: Record<string, string> = {
+  real_estate: "Real Estate",
+  stock: "Stocks",
+  bond: "Bonds",
+  gold: "Gold",
+};
+
+function SectionCard({
+  title,
+  total,
+  children,
+  href,
+}: {
+  title: string;
+  total: number;
+  children: React.ReactNode;
+  href?: string;
+}) {
+  return (
+    <div className="rounded-lg border">
+      <div className="flex items-center justify-between px-4 py-3 border-b">
+        <h2 className="text-sm font-semibold">{title}</h2>
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-semibold">{formatCurrency(total, "USD")}</span>
+          {href && (
+            <Link href={href} className="text-muted-foreground hover:text-foreground">
+              <ArrowRight className="size-4" />
+            </Link>
+          )}
+        </div>
+      </div>
+      <div className="divide-y">{children}</div>
+    </div>
+  );
+}
+
+function Row({ label, value, sub }: { label: string; value: number; sub?: string }) {
+  return (
+    <div className="flex items-center justify-between px-4 py-2">
+      <div>
+        <p className="text-sm">{label}</p>
+        {sub && <p className="text-[10px] text-muted-foreground">{sub}</p>}
+      </div>
+      <p className="text-sm font-medium">{formatCurrency(value, "USD")}</p>
+    </div>
+  );
+}
+
+function AssetsBreakdown({ data }: { data: NetWorthResponse["assets"] }) {
+  return (
+    <>
+      {(
+        Object.entries(data.byType) as [
+          string,
+          { total: number; items: AssetItem[] },
+        ][]
+      )
+        .filter(([, v]) => v.items.length > 0)
+        .map(([type, group]) => (
+          <div key={type}>
+            <div className="flex items-center justify-between px-4 py-2 bg-muted/30">
+              <p className="text-xs font-medium text-muted-foreground">
+                {ASSET_TYPE_LABELS[type]}
+              </p>
+              <p className="text-xs font-medium text-muted-foreground">
+                {formatCurrency(group.total, "USD")}
+              </p>
+            </div>
+            {group.items.map(item => (
+              <Row
+                key={item.id}
+                label={item.name}
+                value={item.valueInUsd}
+                sub={
+                  item.ticker
+                    ? `${item.ticker} · qty ${item.quantity}`
+                    : undefined
+                }
+              />
+            ))}
+          </div>
+        ))}
+    </>
+  );
+}
+
+export default function NetWorthPage() {
+  const { data, isLoading, error } = useQuery<NetWorthResponse>({
+    queryKey: ["networth"],
+    queryFn: getNetWorth,
+  });
+
+  return (
+    <main className="max-w-lg mx-auto px-4 py-8 pb-24">
+      <h1 className="text-2xl font-semibold mb-6">Net Worth</h1>
+
+      {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+      {!isLoading && error && (
+        <p className="text-sm text-destructive">Unable to load net worth.</p>
+      )}
+
+      {data && (
+        <div className="space-y-4">
+          <Card>
+            <CardContent className="py-4 px-4">
+              <p className="text-xs text-muted-foreground">Total Net Worth</p>
+              <p
+                className={`text-3xl font-bold tracking-tight mt-1 ${
+                  data.totalNetWorth >= 0 ? "" : "text-destructive"
+                }`}
+              >
+                {formatCurrency(data.totalNetWorth, "USD")}
+              </p>
+              <div className="mt-3 grid grid-cols-3 gap-2 text-center">
+                <div>
+                  <p className="text-[10px] text-muted-foreground">Liquid</p>
+                  <p className="text-sm font-semibold text-green-600 dark:text-green-400">
+                    {formatCurrency(data.liquid.total, "USD")}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-[10px] text-muted-foreground">Assets</p>
+                  <p className="text-sm font-semibold text-blue-600 dark:text-blue-400">
+                    {formatCurrency(data.assets.total, "USD")}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-[10px] text-muted-foreground">Liabilities</p>
+                  <p className="text-sm font-semibold text-red-600 dark:text-red-400">
+                    {formatCurrency(data.liabilities.total, "USD")}
+                  </p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {data.missingRates.length > 0 && (
+            <div className="flex items-start gap-2 rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-sm text-yellow-700 dark:text-yellow-400">
+              <AlertTriangle className="size-4 mt-0.5 shrink-0" />
+              <span>
+                Missing exchange rates for: {data.missingRates.join(", ")}. Some
+                values shown unconverted.
+              </span>
+            </div>
+          )}
+
+          <SectionCard
+            title="Liquid"
+            total={data.liquid.total}
+            href="/settings/accounts"
+          >
+            {data.liquid.accounts.map((a: AccountItem) => (
+              <Row
+                key={a.id}
+                label={a.name}
+                value={a.valueInUsd}
+                sub={
+                  a.currency !== "USD"
+                    ? formatCurrency(a.balance, a.currency)
+                    : undefined
+                }
+              />
+            ))}
+          </SectionCard>
+
+          {data.assets.total > 0 && (
+            <SectionCard title="Assets" total={data.assets.total} href="/assets">
+              <AssetsBreakdown data={data.assets} />
+            </SectionCard>
+          )}
+
+          {data.liabilities.total > 0 && (
+            <SectionCard
+              title="Liabilities"
+              total={data.liabilities.total}
+              href="/loans"
+            >
+              {data.liabilities.loans.map((l: LoanItem) => (
+                <Row
+                  key={l.id}
+                  label={l.name}
+                  value={l.valueInUsd}
+                  sub={
+                    l.currency !== "USD"
+                      ? `${formatCurrency(l.outstandingPrincipal, l.currency)} outstanding`
+                      : "outstanding"
+                  }
+                />
+              ))}
+            </SectionCard>
+          )}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/app/networth/page.tsx
+++ b/app/networth/page.tsx
@@ -12,6 +12,7 @@ import {
   LoanItem,
 } from "@/lib/api/networth";
 import { formatCurrency } from "@/lib/utils";
+import { Currency } from "@/lib/api/accounts";
 
 const ASSET_TYPE_LABELS: Record<string, string> = {
   real_estate: "Real Estate",
@@ -23,11 +24,13 @@ const ASSET_TYPE_LABELS: Record<string, string> = {
 function SectionCard({
   title,
   total,
+  currency,
   children,
   href,
 }: {
   title: string;
   total: number;
+  currency: Currency;
   children: React.ReactNode;
   href?: string;
 }) {
@@ -36,7 +39,7 @@ function SectionCard({
       <div className="flex items-center justify-between px-4 py-3 border-b">
         <h2 className="text-sm font-semibold">{title}</h2>
         <div className="flex items-center gap-2">
-          <span className="text-sm font-semibold">{formatCurrency(total, "USD")}</span>
+          <span className="text-sm font-semibold">{formatCurrency(total, currency)}</span>
           {href && (
             <Link href={href} className="text-muted-foreground hover:text-foreground">
               <ArrowRight className="size-4" />
@@ -49,19 +52,35 @@ function SectionCard({
   );
 }
 
-function Row({ label, value, sub }: { label: string; value: number; sub?: string }) {
+function Row({
+  label,
+  value,
+  currency,
+  sub,
+}: {
+  label: string;
+  value: number;
+  currency: Currency;
+  sub?: string;
+}) {
   return (
     <div className="flex items-center justify-between px-4 py-2">
       <div>
         <p className="text-sm">{label}</p>
         {sub && <p className="text-[10px] text-muted-foreground">{sub}</p>}
       </div>
-      <p className="text-sm font-medium">{formatCurrency(value, "USD")}</p>
+      <p className="text-sm font-medium">{formatCurrency(value, currency)}</p>
     </div>
   );
 }
 
-function AssetsBreakdown({ data }: { data: NetWorthResponse["assets"] }) {
+function AssetsBreakdown({
+  data,
+  currency,
+}: {
+  data: NetWorthResponse["assets"];
+  currency: Currency;
+}) {
   return (
     <>
       {(
@@ -78,14 +97,15 @@ function AssetsBreakdown({ data }: { data: NetWorthResponse["assets"] }) {
                 {ASSET_TYPE_LABELS[type]}
               </p>
               <p className="text-xs font-medium text-muted-foreground">
-                {formatCurrency(group.total, "USD")}
+                {formatCurrency(group.total, currency)}
               </p>
             </div>
             {group.items.map(item => (
               <Row
                 key={item.id}
                 label={item.name}
-                value={item.valueInUsd}
+                value={item.valueInTarget}
+                currency={currency}
                 sub={
                   item.ticker
                     ? `${item.ticker} · qty ${item.quantity}`
@@ -104,6 +124,8 @@ export default function NetWorthPage() {
     queryKey: ["networth"],
     queryFn: getNetWorth,
   });
+
+  const currency = data?.currency ?? "USD";
 
   return (
     <main className="max-w-lg mx-auto px-4 py-8 pb-24">
@@ -124,25 +146,25 @@ export default function NetWorthPage() {
                   data.totalNetWorth >= 0 ? "" : "text-destructive"
                 }`}
               >
-                {formatCurrency(data.totalNetWorth, "USD")}
+                {formatCurrency(data.totalNetWorth, currency)}
               </p>
               <div className="mt-3 grid grid-cols-3 gap-2 text-center">
                 <div>
                   <p className="text-[10px] text-muted-foreground">Liquid</p>
                   <p className="text-sm font-semibold text-green-600 dark:text-green-400">
-                    {formatCurrency(data.liquid.total, "USD")}
+                    {formatCurrency(data.liquid.total, currency)}
                   </p>
                 </div>
                 <div>
                   <p className="text-[10px] text-muted-foreground">Assets</p>
                   <p className="text-sm font-semibold text-blue-600 dark:text-blue-400">
-                    {formatCurrency(data.assets.total, "USD")}
+                    {formatCurrency(data.assets.total, currency)}
                   </p>
                 </div>
                 <div>
                   <p className="text-[10px] text-muted-foreground">Liabilities</p>
                   <p className="text-sm font-semibold text-red-600 dark:text-red-400">
-                    {formatCurrency(data.liabilities.total, "USD")}
+                    {formatCurrency(data.liabilities.total, currency)}
                   </p>
                 </div>
               </div>
@@ -162,15 +184,17 @@ export default function NetWorthPage() {
           <SectionCard
             title="Liquid"
             total={data.liquid.total}
+            currency={currency}
             href="/settings/accounts"
           >
             {data.liquid.accounts.map((a: AccountItem) => (
               <Row
                 key={a.id}
                 label={a.name}
-                value={a.valueInUsd}
+                value={a.valueInTarget}
+                currency={currency}
                 sub={
-                  a.currency !== "USD"
+                  a.currency !== currency
                     ? formatCurrency(a.balance, a.currency)
                     : undefined
                 }
@@ -179,8 +203,16 @@ export default function NetWorthPage() {
           </SectionCard>
 
           {data.assets.total > 0 && (
-            <SectionCard title="Assets" total={data.assets.total} href="/assets">
-              <AssetsBreakdown data={data.assets} />
+            <SectionCard
+              title="Assets"
+              total={data.assets.total}
+              currency={currency}
+              href="/assets"
+            >
+              <AssetsBreakdown
+                data={data.assets}
+                currency={currency}
+              />
             </SectionCard>
           )}
 
@@ -188,15 +220,17 @@ export default function NetWorthPage() {
             <SectionCard
               title="Liabilities"
               total={data.liabilities.total}
+              currency={currency}
               href="/loans"
             >
               {data.liabilities.loans.map((l: LoanItem) => (
                 <Row
                   key={l.id}
                   label={l.name}
-                  value={l.valueInUsd}
+                  value={l.valueInTarget}
+                  currency={currency}
                   sub={
-                    l.currency !== "USD"
+                    l.currency !== currency
                       ? `${formatCurrency(l.outstandingPrincipal, l.currency)} outstanding`
                       : "outstanding"
                   }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,6 +15,7 @@ import { createTransaction } from "@/lib/api/transactions";
 import { getAccounts } from "@/lib/api/accounts";
 import { getTransactionCategories } from "@/lib/api/transaction-categories";
 import { getExchangeRates } from "@/lib/api/exchange-rates";
+import { getSettings } from "@/lib/api/settings";
 import { formatCurrency } from "@/lib/utils";
 import { Currency } from "@/lib/api/accounts";
 import api from "@/lib/axios";
@@ -130,6 +131,7 @@ export default function Home() {
     queryFn: () => getMonthlySummary(timeRange),
   });
   const { data: accounts = [] } = useQuery({ queryKey: ["accounts"], queryFn: getAccounts });
+  const { data: settings } = useQuery({ queryKey: ["settings"], queryFn: getSettings });
   const { data: exchangeRates = [] } = useQuery({ queryKey: ["exchange-rates"], queryFn: getExchangeRates });
   const { data: categories = [] } = useQuery({
     queryKey: ["transaction-categories"],
@@ -144,9 +146,7 @@ export default function Home() {
     },
   });
 
-  // Use default account's currency or fallback to USD
-  const defaultAccount = accounts.find(acc => acc.isDefault);
-  const currency = defaultAccount?.currency ?? accounts[0]?.currency ?? "USD";
+  const currency = (settings?.defaultCurrency ?? "USD") as Currency;
 
   // Total balance across all accounts converted to default currency
   const totalBalance = accounts.reduce((sum, account) => {

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -3,7 +3,10 @@
 import { useState } from "react";
 import Link from "next/link";
 import { ChevronRight, CreditCard, Tag, User, DollarSign, Upload, Landmark } from "lucide-react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { ImportDialog } from "@/components/transactions/import-dialog";
+import { getSettings, updateSettings } from "@/lib/api/settings";
+import { Currency } from "@/lib/api/accounts";
 
 const SETTINGS_ITEMS = [
   { href: "/settings/account", label: "User", description: "Manage password and logout", icon: User },
@@ -13,12 +16,40 @@ const SETTINGS_ITEMS = [
   { href: "/settings/loan-categories", label: "Loan Defaults", description: "Default categories for loan payments", icon: Landmark },
 ];
 
+const CURRENCIES: { value: Currency; label: string }[] = [
+  { value: "USD", label: "USD — US Dollar" },
+  { value: "VND", label: "VND — Vietnamese Dong" },
+];
+
 export default function SettingsPage() {
   const [importOpen, setImportOpen] = useState(false);
+  const queryClient = useQueryClient();
+
+  const { data: settings } = useQuery({ queryKey: ["settings"], queryFn: getSettings });
+  const updateMutation = useMutation({
+    mutationFn: updateSettings,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["settings"] }),
+  });
 
   return (
-    <main className="max-w-lg mx-auto px-4 py-8">
-<div className="divide-y rounded-lg border overflow-hidden">
+    <main className="max-w-lg mx-auto px-4 py-8 space-y-4">
+      <div className="rounded-lg border px-4 py-3 flex items-center justify-between">
+        <div>
+          <p className="text-sm font-medium">Display Currency</p>
+          <p className="text-xs text-muted-foreground">All summaries are converted to this currency</p>
+        </div>
+        <select
+          className="text-sm border rounded-md px-2 py-1.5 bg-background"
+          value={settings?.defaultCurrency ?? "USD"}
+          onChange={e => updateMutation.mutate({ defaultCurrency: e.target.value as Currency })}
+        >
+          {CURRENCIES.map(c => (
+            <option key={c.value} value={c.value}>{c.label}</option>
+          ))}
+        </select>
+      </div>
+
+      <div className="divide-y rounded-lg border overflow-hidden">
         {SETTINGS_ITEMS.map(({ href, label, description, icon: Icon }) => (
           <Link
             key={href}
@@ -52,5 +83,6 @@ export default function SettingsPage() {
 
       <ImportDialog open={importOpen} onClose={() => setImportOpen(false)} />
     </main>
+
   );
 }

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -19,10 +19,7 @@ const SETTINGS_ITEMS = [
   { href: "/settings/loan-categories", label: "Loan Defaults", description: "Default categories for loan payments", icon: Landmark },
 ];
 
-const CURRENCIES: { value: Currency; label: string }[] = [
-  { value: "USD", label: "USD — US Dollar" },
-  { value: "VND", label: "VND — Vietnamese Dong" },
-];
+const CURRENCIES: Currency[] = ["USD", "VND"];
 
 export default function SettingsPage() {
   const [importOpen, setImportOpen] = useState(false);
@@ -36,20 +33,27 @@ export default function SettingsPage() {
 
   return (
     <main className="max-w-lg mx-auto px-4 py-8 space-y-4">
-      <div className="rounded-lg border px-4 py-3 flex items-center justify-between">
-        <div>
-          <p className="text-sm font-medium">Display Currency</p>
-          <p className="text-xs text-muted-foreground">All summaries are converted to this currency</p>
+      <div className="rounded-lg border px-4 py-3">
+        <p className="text-sm font-medium mb-0.5">Display Currency</p>
+        <p className="text-xs text-muted-foreground mb-3">All summaries are converted to this currency</p>
+        <div className="flex rounded-lg border overflow-hidden">
+          {CURRENCIES.map(c => {
+            const active = (settings?.defaultCurrency ?? "USD") === c;
+            return (
+              <button
+                key={c}
+                onClick={() => updateMutation.mutate({ defaultCurrency: c })}
+                className={`flex-1 py-2 text-sm font-medium transition-colors ${
+                  active
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                {c}
+              </button>
+            );
+          })}
         </div>
-        <select
-          className="text-sm border rounded-md px-2 py-1.5 bg-background"
-          value={settings?.defaultCurrency ?? "USD"}
-          onChange={e => updateMutation.mutate({ defaultCurrency: e.target.value as Currency })}
-        >
-          {CURRENCIES.map(c => (
-            <option key={c.value} value={c.value}>{c.label}</option>
-          ))}
-        </select>
       </div>
 
       <div className="divide-y rounded-lg border overflow-hidden">

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -2,13 +2,16 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { ChevronRight, CreditCard, Tag, User, DollarSign, Upload, Landmark } from "lucide-react";
+import { ChevronRight, CreditCard, Tag, User, DollarSign, Upload, Landmark, PiggyBank, Building2, HandCoins } from "lucide-react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { ImportDialog } from "@/components/transactions/import-dialog";
 import { getSettings, updateSettings } from "@/lib/api/settings";
 import { Currency } from "@/lib/api/accounts";
 
 const SETTINGS_ITEMS = [
+  { href: "/budgets", label: "Budgets", description: "Set and track spending budgets", icon: PiggyBank },
+  { href: "/assets", label: "Assets", description: "Manage real estate, stocks, gold", icon: Building2 },
+  { href: "/loans", label: "Loans", description: "Track borrowed and lent money", icon: HandCoins },
   { href: "/settings/account", label: "User", description: "Manage password and logout", icon: User },
   { href: "/settings/accounts", label: "Accounts", description: "Manage your bank accounts", icon: CreditCard },
   { href: "/settings/categories", label: "Categories", description: "Manage transaction categories", icon: Tag },

--- a/components/assets/asset-card.tsx
+++ b/components/assets/asset-card.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { RefreshCw, Pencil } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Asset } from "@/lib/api/assets";
+import { formatCurrency } from "@/lib/utils";
+
+const TYPE_LABELS: Record<string, string> = {
+  real_estate: "Real Estate",
+  stock: "Stock",
+  bond: "Bond",
+  gold: "Gold",
+};
+
+interface AssetCardProps {
+  asset: Asset;
+  onEdit: (asset: Asset) => void;
+  onRefreshPrice: (asset: Asset) => void;
+  refreshing?: boolean;
+}
+
+export function AssetCard({ asset, onEdit, onRefreshPrice, refreshing }: AssetCardProps) {
+  const canRefresh = asset.type === "stock" || asset.type === "gold";
+  const lastPriced = asset.lastPricedAt
+    ? new Date(asset.lastPricedAt).toLocaleDateString()
+    : null;
+
+  return (
+    <div className="flex items-center justify-between rounded-lg border p-3 gap-3">
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium truncate">{asset.name}</span>
+          <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[10px] text-muted-foreground">
+            {TYPE_LABELS[asset.type]}
+          </span>
+        </div>
+        <p className="text-base font-semibold mt-0.5">
+          {formatCurrency(asset.currentValue, asset.currency)}
+        </p>
+        {lastPriced && (
+          <p className="text-[10px] text-muted-foreground">Last priced: {lastPriced}</p>
+        )}
+      </div>
+      <div className="flex items-center gap-1 shrink-0">
+        {canRefresh && (
+          <Button
+            size="icon"
+            variant="ghost"
+            className="size-8"
+            onClick={() => onRefreshPrice(asset)}
+            disabled={refreshing}
+          >
+            <RefreshCw className={`size-4 ${refreshing ? "animate-spin" : ""}`} />
+          </Button>
+        )}
+        <Button
+          size="icon"
+          variant="ghost"
+          className="size-8"
+          onClick={() => onEdit(asset)}
+        >
+          <Pencil className="size-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/assets/asset-form.tsx
+++ b/components/assets/asset-form.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+import { FormEvent, useEffect, useState } from "react";
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Asset, AssetPayload, AssetType } from "@/lib/api/assets";
+import { Currency } from "@/lib/api/accounts";
+
+const ASSET_TYPE_OPTIONS: { value: AssetType; label: string }[] = [
+  { value: "real_estate", label: "Real Estate" },
+  { value: "stock", label: "Stock" },
+  { value: "bond", label: "Bond" },
+  { value: "gold", label: "Gold" },
+];
+
+const CURRENCY_OPTIONS: { value: Currency; label: string }[] = [
+  { value: "USD", label: "USD" },
+  { value: "VND", label: "VND" },
+];
+
+function NativeSelect({ id, name, value, options, onChange, required }: {
+  id: string; name: string; value: string; required?: boolean;
+  options: { value: string; label: string }[];
+  onChange: (value: string) => void;
+}) {
+  return (
+    <select
+      id={id}
+      name={name}
+      value={value}
+      required={required}
+      onChange={e => onChange(e.target.value)}
+      className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-[16px] md:text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+    >
+      {options.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+    </select>
+  );
+}
+
+interface AssetFormProps {
+  open: boolean;
+  asset?: Asset | null;
+  onClose: () => void;
+  onSubmit: (payload: AssetPayload) => Promise<void>;
+  onDelete?: (asset: Asset) => Promise<void>;
+}
+
+export function AssetForm({ open, asset, onClose, onSubmit, onDelete }: AssetFormProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [type, setType] = useState<AssetType>(asset?.type ?? "stock");
+  const [currency, setCurrency] = useState<Currency>(asset?.currency ?? "USD");
+
+  useEffect(() => {
+    if (!open) return;
+    setError("");
+    setConfirmDelete(false);
+    setType(asset?.type ?? "stock");
+    setCurrency(asset?.currency ?? "USD");
+  }, [open, asset]);
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+    const form = e.currentTarget;
+    const get = (name: string) => (form.elements.namedItem(name) as HTMLInputElement)?.value ?? "";
+
+    const metadata: Record<string, unknown> = {};
+    if (type === "real_estate") {
+      metadata.address = get("address");
+      metadata.purchasePrice = get("purchasePrice") ? Number(get("purchasePrice")) : undefined;
+      metadata.purchaseDate = get("purchaseDate") || undefined;
+    } else if (type === "stock") {
+      metadata.exchange = get("exchange");
+    } else if (type === "bond") {
+      metadata.issuer = get("issuer");
+      metadata.interestRate = get("interestRate") ? Number(get("interestRate")) : undefined;
+      metadata.maturityDate = get("maturityDate") || undefined;
+    } else if (type === "gold") {
+      metadata.form = get("goldForm");
+    }
+
+    const payload: AssetPayload = {
+      name: get("name"),
+      type,
+      currency,
+      currentValue: Number(get("currentValue")),
+      quantity: get("quantity") ? Number(get("quantity")) : null,
+      ticker: get("ticker") || null,
+      metadata,
+    };
+
+    try {
+      await onSubmit(payload);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const meta = asset?.metadata as Record<string, unknown> | undefined;
+
+  return (
+    <Dialog open={open} onOpenChange={next => !next && onClose()}>
+      <DialogContent className="w-[95vw] max-w-lg max-h-[90dvh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{asset ? "Edit Asset" : "Add Asset"}</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4 py-2" key={asset?.id ?? "new"}>
+          <div className="space-y-2">
+            <Label htmlFor="name">Name</Label>
+            <Input id="name" name="name" placeholder="e.g. Apple shares" defaultValue={asset?.name ?? ""} required />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-2">
+              <Label htmlFor="type">Type</Label>
+              <NativeSelect id="type"
+name="type"
+value={type}
+onChange={v => setType(v as AssetType)}
+                options={ASSET_TYPE_OPTIONS} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="currency">Currency</Label>
+              <NativeSelect id="currency"
+name="currency"
+value={currency}
+onChange={v => setCurrency(v as Currency)}
+                options={CURRENCY_OPTIONS} />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-2">
+              <Label htmlFor="currentValue">Current Value</Label>
+              <Input id="currentValue"
+name="currentValue"
+type="number"
+step="any"
+min="0"
+                defaultValue={asset?.currentValue ?? ""}
+required />
+            </div>
+            {(type === "stock" || type === "gold") && (
+              <div className="space-y-2">
+                <Label htmlFor="quantity">{type === "gold" ? "Quantity (oz)" : "Shares"}</Label>
+                <Input id="quantity"
+name="quantity"
+type="number"
+step="any"
+min="0"
+                  defaultValue={asset?.quantity ?? ""}
+required />
+              </div>
+            )}
+          </div>
+
+          {type === "stock" && (
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-2">
+                <Label htmlFor="ticker">Ticker</Label>
+                <Input id="ticker"
+name="ticker"
+placeholder="e.g. AAPL"
+                  defaultValue={asset?.ticker ?? ""}
+required />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="exchange">Exchange</Label>
+                <Input id="exchange"
+name="exchange"
+placeholder="e.g. NASDAQ"
+                  defaultValue={meta?.exchange as string ?? ""} />
+              </div>
+            </div>
+          )}
+
+          {type === "real_estate" && (
+            <>
+              <div className="space-y-2">
+                <Label htmlFor="address">Address</Label>
+                <Input id="address"
+name="address"
+placeholder="e.g. 123 Main St"
+                  defaultValue={meta?.address as string ?? ""} />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-2">
+                  <Label htmlFor="purchasePrice">Purchase Price</Label>
+                  <Input id="purchasePrice"
+name="purchasePrice"
+type="number"
+step="any"
+min="0"
+                    defaultValue={meta?.purchasePrice as number ?? ""} />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="purchaseDate">Purchase Date</Label>
+                  <Input id="purchaseDate"
+name="purchaseDate"
+type="date"
+                    defaultValue={meta?.purchaseDate as string ?? ""} />
+                </div>
+              </div>
+            </>
+          )}
+
+          {type === "bond" && (
+            <>
+              <div className="space-y-2">
+                <Label htmlFor="issuer">Issuer</Label>
+                <Input id="issuer"
+name="issuer"
+placeholder="e.g. US Treasury"
+                  defaultValue={meta?.issuer as string ?? ""} />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-2">
+                  <Label htmlFor="interestRate">Interest Rate (%)</Label>
+                  <Input id="interestRate"
+name="interestRate"
+type="number"
+step="0.01"
+min="0"
+                    defaultValue={meta?.interestRate as number ?? ""} />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="maturityDate">Maturity Date</Label>
+                  <Input id="maturityDate"
+name="maturityDate"
+type="date"
+                    defaultValue={meta?.maturityDate as string ?? ""} />
+                </div>
+              </div>
+            </>
+          )}
+
+          {type === "gold" && (
+            <div className="space-y-2">
+              <Label htmlFor="goldForm">Form</Label>
+              <select
+                id="goldForm"
+                name="goldForm"
+                defaultValue={meta?.form as string ?? "physical"}
+                className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-[16px] md:text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                <option value="physical">Physical</option>
+                <option value="ETF">ETF</option>
+              </select>
+            </div>
+          )}
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+
+          <div className="flex items-center justify-between gap-2 pt-2">
+            <div>
+              {asset && onDelete && (
+                confirmDelete
+                  ? <p className="text-sm text-destructive">Delete this asset?</p>
+                  : <Button type="button"
+variant="outline"
+                      className="text-destructive hover:text-destructive border-destructive/40 hover:border-destructive"
+                      onClick={() => setConfirmDelete(true)}
+disabled={loading}>
+                      <Trash2 className="size-4 mr-1" />Delete
+                    </Button>
+              )}
+            </div>
+            <div className="flex gap-2">
+              {confirmDelete ? (
+                <>
+                  <Button type="button" variant="outline" onClick={() => setConfirmDelete(false)}>Cancel</Button>
+                  <Button type="button"
+variant="destructive"
+disabled={loading}
+                    onClick={async () => {
+                      setLoading(true);
+                      try { await onDelete?.(asset!); onClose(); }
+                      finally { setLoading(false); }
+                    }}>
+                    {loading ? "Deleting…" : "Confirm Delete"}
+                  </Button>
+                </>
+              ) : (
+                <>
+                  <Button type="button" variant="outline" onClick={onClose} disabled={loading}>Cancel</Button>
+                  <Button type="submit" disabled={loading}>{loading ? "Saving…" : asset ? "Save Changes" : "Add Asset"}</Button>
+                </>
+              )}
+            </div>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/bottom-nav.tsx
+++ b/components/bottom-nav.tsx
@@ -2,15 +2,12 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Building2, HandCoins, Home, List, PiggyBank, Settings, TrendingUp } from "lucide-react";
+import { Home, List, Settings, TrendingUp } from "lucide-react";
 
 const NAV_ITEMS = [
   { href: "/", label: "Home", icon: Home },
   { href: "/transactions", label: "Transactions", icon: List },
-  { href: "/budgets", label: "Budgets", icon: PiggyBank },
   { href: "/networth", label: "Net Worth", icon: TrendingUp },
-  { href: "/assets", label: "Assets", icon: Building2 },
-  { href: "/loans", label: "Loans", icon: HandCoins },
   { href: "/settings", label: "Settings", icon: Settings },
 ];
 

--- a/components/bottom-nav.tsx
+++ b/components/bottom-nav.tsx
@@ -2,12 +2,14 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { HandCoins, Home, List, PiggyBank, Settings } from "lucide-react";
+import { Building2, HandCoins, Home, List, PiggyBank, Settings, TrendingUp } from "lucide-react";
 
 const NAV_ITEMS = [
   { href: "/", label: "Home", icon: Home },
   { href: "/transactions", label: "Transactions", icon: List },
   { href: "/budgets", label: "Budgets", icon: PiggyBank },
+  { href: "/networth", label: "Net Worth", icon: TrendingUp },
+  { href: "/assets", label: "Assets", icon: Building2 },
   { href: "/loans", label: "Loans", icon: HandCoins },
   { href: "/settings", label: "Settings", icon: Settings },
 ];

--- a/docs/superpowers/plans/2026-05-11-assets-networth.md
+++ b/docs/superpowers/plans/2026-05-11-assets-networth.md
@@ -1,0 +1,1389 @@
+# Assets & Net Worth Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add asset tracking (real estate, stocks, bonds, gold) and a net worth page aggregating accounts + assets − loan liabilities.
+
+**Architecture:** A unified `Asset` Prisma model with a `type` enum and a `metadata` JSON column holds all asset types. Live price refresh for stocks (Yahoo Finance) and gold (metals-api) is a dedicated POST endpoint. A `/api/networth` endpoint aggregates accounts, assets, and loan remaining principal with currency conversion using the existing `ExchangeRate` model.
+
+**Tech Stack:** Next.js App Router, Prisma (PostgreSQL), React Query, Axios, shadcn/ui, Tailwind CSS
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Modify | `prisma/schema.prisma` | Add `AssetType` enum + `Asset` model |
+| Create | `app/api/assets/asset-route-utils.ts` | Shared parsing, validation, ownership check |
+| Create | `app/api/assets/route.ts` | GET list, POST create |
+| Create | `app/api/assets/[id]/route.ts` | GET, PATCH, DELETE |
+| Create | `app/api/assets/[id]/refresh-price/route.ts` | POST — fetch live price |
+| Create | `app/api/networth/route.ts` | GET — aggregate net worth |
+| Create | `lib/api/assets.ts` | Client-side types + API calls |
+| Create | `lib/api/networth.ts` | Client-side types + API call |
+| Create | `components/assets/asset-form.tsx` | Create/edit dialog, dynamic fields by type |
+| Create | `components/assets/asset-card.tsx` | Asset row with refresh button |
+| Create | `app/assets/page.tsx` | CRUD list page |
+| Create | `app/networth/page.tsx` | Read-only aggregate view |
+| Modify | `components/bottom-nav.tsx` | Add Net Worth + Assets nav items |
+
+---
+
+## Task 1: Prisma Schema — Add Asset Model
+
+**Files:**
+- Modify: `prisma/schema.prisma`
+
+- [ ] **Step 1: Add the AssetType enum and Asset model**
+
+Add this block to `prisma/schema.prisma` after the `ExchangeRate` model:
+
+```prisma
+enum AssetType {
+  real_estate
+  stock
+  bond
+  gold
+}
+
+model Asset {
+  id           String    @id @default(cuid())
+  name         String
+  type         AssetType
+  currency     Currency  @default(USD)
+  currentValue Float
+  quantity     Float?
+  ticker       String?
+  metadata     Json      @default("{}")
+  lastPricedAt DateTime?
+  userId       String
+  user         User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
+
+  @@index([userId, type])
+}
+```
+
+Also add `assets Asset[]` to the `User` model's relation list (after `loans Loan[]`):
+
+```prisma
+assets               Asset[]
+```
+
+- [ ] **Step 2: Run the migration**
+
+```bash
+pnpm prisma migrate dev --name add-assets
+```
+
+Expected: migration file created, client regenerated, no errors.
+
+- [ ] **Step 3: Verify types are generated**
+
+```bash
+pnpm exec tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add prisma/schema.prisma prisma/migrations/
+git commit -m "feat: add Asset model to schema"
+```
+
+---
+
+## Task 2: Asset Route Utils
+
+**Files:**
+- Create: `app/api/assets/asset-route-utils.ts`
+
+- [ ] **Step 1: Create the file**
+
+```typescript
+import { AssetType, Currency, Prisma } from "@prisma/client";
+import { prisma } from "@/app/lib/db";
+
+const ASSET_TYPES = new Set<AssetType>(["real_estate", "stock", "bond", "gold"]);
+const CURRENCIES = new Set<Currency>(["USD", "VND"]);
+
+export interface AssetPayload {
+  name: string;
+  type: string;
+  currency?: string;
+  currentValue: number;
+  quantity?: number | null;
+  ticker?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export function parseAssetPayload(payload: AssetPayload) {
+  const name = payload.name?.trim();
+  if (!name) throw new Error("Name is required");
+  if (!ASSET_TYPES.has(payload.type as AssetType)) throw new Error("Invalid asset type");
+  const currency = (payload.currency ?? "USD") as Currency;
+  if (!CURRENCIES.has(currency)) throw new Error("Invalid currency");
+  const currentValue = Number(payload.currentValue);
+  if (!Number.isFinite(currentValue) || currentValue < 0) throw new Error("Current value must be a non-negative number");
+  if (payload.type === "stock") {
+    if (!payload.ticker?.trim()) throw new Error("Ticker is required for stocks");
+    if (!payload.quantity || Number(payload.quantity) <= 0) throw new Error("Quantity must be positive for stocks");
+  }
+  if (payload.type === "gold") {
+    if (!payload.quantity || Number(payload.quantity) <= 0) throw new Error("Quantity must be positive for gold");
+  }
+  return {
+    name,
+    type: payload.type as AssetType,
+    currency,
+    currentValue,
+    quantity: payload.quantity != null ? Number(payload.quantity) : null,
+    ticker: payload.ticker?.trim() || null,
+    metadata: payload.metadata ?? {},
+  };
+}
+
+export async function getOwnedAsset(id: string, userId: string) {
+  return prisma.asset.findFirst({ where: { id, userId } });
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+pnpm exec tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/api/assets/asset-route-utils.ts
+git commit -m "feat: add asset route utils"
+```
+
+---
+
+## Task 3: Assets List & Create API
+
+**Files:**
+- Create: `app/api/assets/route.ts`
+
+- [ ] **Step 1: Create the file**
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/app/lib/db";
+import { getSession } from "@/app/lib/auth";
+import { parseAssetPayload, AssetPayload } from "./asset-route-utils";
+
+export async function GET(req: NextRequest) {
+  const session = await getSession(req);
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const assets = await prisma.asset.findMany({
+    where: { userId: session.userId },
+    orderBy: [{ type: "asc" }, { createdAt: "desc" }],
+  });
+
+  return NextResponse.json(assets);
+}
+
+export async function POST(req: NextRequest) {
+  const session = await getSession(req);
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  try {
+    const parsed = parseAssetPayload(await req.json() as AssetPayload);
+    const asset = await prisma.asset.create({
+      data: { ...parsed, userId: session.userId },
+    });
+    return NextResponse.json(asset, { status: 201 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unable to create asset";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+pnpm exec tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/api/assets/route.ts
+git commit -m "feat: add assets list and create API"
+```
+
+---
+
+## Task 4: Asset Detail API (GET, PATCH, DELETE)
+
+**Files:**
+- Create: `app/api/assets/[id]/route.ts`
+
+- [ ] **Step 1: Create the file**
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/app/lib/db";
+import { getSession } from "@/app/lib/auth";
+import { getOwnedAsset, parseAssetPayload, AssetPayload } from "../asset-route-utils";
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getSession(req);
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+  const asset = await getOwnedAsset(id, session.userId);
+  if (!asset) return NextResponse.json({ error: "Asset not found" }, { status: 404 });
+
+  return NextResponse.json(asset);
+}
+
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getSession(req);
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+  const existing = await getOwnedAsset(id, session.userId);
+  if (!existing) return NextResponse.json({ error: "Asset not found" }, { status: 404 });
+
+  try {
+    const parsed = parseAssetPayload(await req.json() as AssetPayload);
+    const updated = await prisma.asset.update({ where: { id }, data: parsed });
+    return NextResponse.json(updated);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unable to update asset";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getSession(req);
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+  const asset = await getOwnedAsset(id, session.userId);
+  if (!asset) return NextResponse.json({ error: "Asset not found" }, { status: 404 });
+
+  await prisma.asset.delete({ where: { id } });
+  return NextResponse.json({ success: true });
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+pnpm exec tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "app/api/assets/[id]/route.ts"
+git commit -m "feat: add asset detail API"
+```
+
+---
+
+## Task 5: Asset Price Refresh API
+
+**Files:**
+- Create: `app/api/assets/[id]/refresh-price/route.ts`
+
+- [ ] **Step 1: Create the file**
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/app/lib/db";
+import { getSession } from "@/app/lib/auth";
+import { getOwnedAsset } from "../../asset-route-utils";
+
+async function fetchStockPrice(ticker: string): Promise<number> {
+  const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(ticker)}?interval=1d&range=1d`;
+  const res = await fetch(url, { headers: { "User-Agent": "Mozilla/5.0" }, next: { revalidate: 0 } });
+  if (!res.ok) throw new Error(`Yahoo Finance returned ${res.status} for ticker ${ticker}`);
+  const json = await res.json();
+  const price = json?.chart?.result?.[0]?.meta?.regularMarketPrice;
+  if (!price) throw new Error(`Could not parse price for ticker ${ticker}`);
+  return price;
+}
+
+async function fetchGoldPriceUsd(): Promise<number> {
+  // Open Exchange Rates free endpoint for XAU (gold) per USD
+  const res = await fetch("https://open.er-api.com/v6/latest/XAU", { next: { revalidate: 0 } });
+  if (!res.ok) throw new Error(`Gold price fetch returned ${res.status}`);
+  const json = await res.json();
+  const usdPerOz = json?.rates?.USD;
+  if (!usdPerOz) throw new Error("Could not parse gold price");
+  return usdPerOz;
+}
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getSession(req);
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+  const asset = await getOwnedAsset(id, session.userId);
+  if (!asset) return NextResponse.json({ error: "Asset not found" }, { status: 404 });
+
+  if (asset.type !== "stock" && asset.type !== "gold") {
+    return NextResponse.json({ error: "Price refresh is only supported for stocks and gold" }, { status: 400 });
+  }
+
+  try {
+    let pricePerUnit: number;
+    if (asset.type === "stock") {
+      if (!asset.ticker) return NextResponse.json({ error: "Asset has no ticker" }, { status: 400 });
+      pricePerUnit = await fetchStockPrice(asset.ticker);
+    } else {
+      pricePerUnit = await fetchGoldPriceUsd();
+    }
+
+    const quantity = asset.quantity ?? 1;
+    const currentValue = pricePerUnit * quantity;
+
+    const updated = await prisma.asset.update({
+      where: { id },
+      data: { currentValue, lastPricedAt: new Date() },
+    });
+    return NextResponse.json(updated);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Price fetch failed";
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+pnpm exec tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "app/api/assets/[id]/refresh-price/route.ts"
+git commit -m "feat: add asset price refresh API"
+```
+
+---
+
+## Task 6: Net Worth API
+
+**Files:**
+- Create: `app/api/networth/route.ts`
+
+- [ ] **Step 1: Create the file**
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/app/lib/db";
+import { getSession } from "@/app/lib/auth";
+import { Currency } from "@prisma/client";
+
+function convertToUsd(amount: number, currency: Currency, rates: { fromCurrency: string; toCurrency: string; rate: number }[]): number {
+  if (currency === "USD") return amount;
+  const direct = rates.find(r => r.fromCurrency === currency && r.toCurrency === "USD");
+  if (direct) return amount * direct.rate;
+  const inverse = rates.find(r => r.fromCurrency === "USD" && r.toCurrency === currency);
+  if (inverse) return amount / inverse.rate;
+  return amount; // no rate found — return as-is, flagged in response
+}
+
+export async function GET(req: NextRequest) {
+  const session = await getSession(req);
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const [accounts, assets, loans, exchangeRates] = await Promise.all([
+    prisma.account.findMany({ where: { userId: session.userId } }),
+    prisma.asset.findMany({ where: { userId: session.userId } }),
+    prisma.loan.findMany({
+      where: { userId: session.userId, status: "active" },
+      include: {
+        initialTransaction: { select: { amount: true } },
+        payments: {
+          include: {
+            principalTransaction: { select: { amount: true } },
+          },
+        },
+      },
+    }),
+    prisma.exchangeRate.findMany({ where: { userId: session.userId } }),
+  ]);
+
+  const missingRates: string[] = [];
+
+  const accountItems = accounts.map(a => {
+    const valueInUsd = convertToUsd(a.balance, a.currency, exchangeRates);
+    if (a.currency !== "USD" && valueInUsd === a.balance) missingRates.push(`${a.currency}/USD`);
+    return { id: a.id, name: a.name, balance: a.balance, currency: a.currency, valueInUsd };
+  });
+
+  const assetItems = assets.map(a => {
+    const valueInUsd = convertToUsd(a.currentValue, a.currency, exchangeRates);
+    if (a.currency !== "USD" && valueInUsd === a.currentValue) missingRates.push(`${a.currency}/USD`);
+    return { ...a, valueInUsd };
+  });
+
+  const loanItems = loans.map(loan => {
+    const principalAmount = loan.initialTransaction?.amount ?? 0;
+    const paidPrincipal = loan.payments.reduce((sum, p) => sum + (p.principalTransaction?.amount ?? 0), 0);
+    const outstandingPrincipal = Math.max(0, principalAmount - paidPrincipal);
+    const valueInUsd = convertToUsd(outstandingPrincipal, loan.currency, exchangeRates);
+    return { id: loan.id, name: loan.name, direction: loan.direction, outstandingPrincipal, currency: loan.currency, valueInUsd };
+  });
+
+  // Only borrowed loans count as liabilities; lent loans are assets (receivables) — omit for simplicity
+  const borrowedLoans = loanItems.filter(l => l.direction === "borrowed");
+
+  const liquidTotal = accountItems.reduce((s, a) => s + a.valueInUsd, 0);
+  const assetsByType = {
+    real_estate: assetItems.filter(a => a.type === "real_estate"),
+    stock: assetItems.filter(a => a.type === "stock"),
+    bond: assetItems.filter(a => a.type === "bond"),
+    gold: assetItems.filter(a => a.type === "gold"),
+  } as const;
+  const assetsTotal = assetItems.reduce((s, a) => s + a.valueInUsd, 0);
+  const liabilitiesTotal = borrowedLoans.reduce((s, l) => s + l.valueInUsd, 0);
+
+  return NextResponse.json({
+    totalNetWorth: liquidTotal + assetsTotal - liabilitiesTotal,
+    missingRates: [...new Set(missingRates)],
+    liquid: { total: liquidTotal, accounts: accountItems },
+    assets: {
+      total: assetsTotal,
+      byType: {
+        real_estate: { total: assetsByType.real_estate.reduce((s, a) => s + a.valueInUsd, 0), items: assetsByType.real_estate },
+        stock: { total: assetsByType.stock.reduce((s, a) => s + a.valueInUsd, 0), items: assetsByType.stock },
+        bond: { total: assetsByType.bond.reduce((s, a) => s + a.valueInUsd, 0), items: assetsByType.bond },
+        gold: { total: assetsByType.gold.reduce((s, a) => s + a.valueInUsd, 0), items: assetsByType.gold },
+      },
+    },
+    liabilities: { total: liabilitiesTotal, loans: borrowedLoans },
+  });
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+pnpm exec tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/api/networth/route.ts
+git commit -m "feat: add net worth API"
+```
+
+---
+
+## Task 7: API Client Files
+
+**Files:**
+- Create: `lib/api/assets.ts`
+- Create: `lib/api/networth.ts`
+
+- [ ] **Step 1: Create `lib/api/assets.ts`**
+
+```typescript
+import api from "@/lib/axios";
+import { Currency } from "./accounts";
+
+export type AssetType = "real_estate" | "stock" | "bond" | "gold";
+
+export interface Asset {
+  id: string;
+  name: string;
+  type: AssetType;
+  currency: Currency;
+  currentValue: number;
+  quantity: number | null;
+  ticker: string | null;
+  metadata: Record<string, unknown>;
+  lastPricedAt: string | null;
+  userId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AssetPayload {
+  name: string;
+  type: AssetType;
+  currency?: Currency;
+  currentValue: number;
+  quantity?: number | null;
+  ticker?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export async function getAssets(): Promise<Asset[]> {
+  const { data } = await api.get<Asset[]>("/assets");
+  return data;
+}
+
+export async function getAsset(id: string): Promise<Asset> {
+  const { data } = await api.get<Asset>(`/assets/${id}`);
+  return data;
+}
+
+export async function createAsset(payload: AssetPayload): Promise<Asset> {
+  const { data } = await api.post<Asset>("/assets", payload);
+  return data;
+}
+
+export async function updateAsset(id: string, payload: AssetPayload): Promise<Asset> {
+  const { data } = await api.patch<Asset>(`/assets/${id}`, payload);
+  return data;
+}
+
+export async function deleteAsset(id: string): Promise<void> {
+  await api.delete(`/assets/${id}`);
+}
+
+export async function refreshAssetPrice(id: string): Promise<Asset> {
+  const { data } = await api.post<Asset>(`/assets/${id}/refresh-price`);
+  return data;
+}
+```
+
+- [ ] **Step 2: Create `lib/api/networth.ts`**
+
+```typescript
+import api from "@/lib/axios";
+import { Currency } from "./accounts";
+import { AssetType } from "./assets";
+
+export interface AccountItem {
+  id: string;
+  name: string;
+  balance: number;
+  currency: Currency;
+  valueInUsd: number;
+}
+
+export interface AssetItem {
+  id: string;
+  name: string;
+  type: AssetType;
+  currency: Currency;
+  currentValue: number;
+  quantity: number | null;
+  ticker: string | null;
+  lastPricedAt: string | null;
+  valueInUsd: number;
+}
+
+export interface LoanItem {
+  id: string;
+  name: string;
+  direction: "borrowed" | "lent";
+  outstandingPrincipal: number;
+  currency: Currency;
+  valueInUsd: number;
+}
+
+export interface AssetsByType {
+  real_estate: { total: number; items: AssetItem[] };
+  stock: { total: number; items: AssetItem[] };
+  bond: { total: number; items: AssetItem[] };
+  gold: { total: number; items: AssetItem[] };
+}
+
+export interface NetWorthResponse {
+  totalNetWorth: number;
+  missingRates: string[];
+  liquid: { total: number; accounts: AccountItem[] };
+  assets: { total: number; byType: AssetsByType };
+  liabilities: { total: number; loans: LoanItem[] };
+}
+
+export async function getNetWorth(): Promise<NetWorthResponse> {
+  const { data } = await api.get<NetWorthResponse>("/networth");
+  return data;
+}
+```
+
+- [ ] **Step 3: Type-check**
+
+```bash
+pnpm exec tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/api/assets.ts lib/api/networth.ts
+git commit -m "feat: add assets and networth API client files"
+```
+
+---
+
+## Task 8: Asset Form Component
+
+**Files:**
+- Create: `components/assets/asset-form.tsx`
+
+- [ ] **Step 1: Create the file**
+
+```typescript
+"use client";
+
+import { FormEvent, useEffect, useState } from "react";
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Asset, AssetPayload, AssetType } from "@/lib/api/assets";
+import { Currency } from "@/lib/api/accounts";
+
+const ASSET_TYPE_OPTIONS: { value: AssetType; label: string }[] = [
+  { value: "real_estate", label: "Real Estate" },
+  { value: "stock", label: "Stock" },
+  { value: "bond", label: "Bond" },
+  { value: "gold", label: "Gold" },
+];
+
+const CURRENCY_OPTIONS: { value: Currency; label: string }[] = [
+  { value: "USD", label: "USD" },
+  { value: "VND", label: "VND" },
+];
+
+function NativeSelect({ id, name, value, options, onChange, required }: {
+  id: string; name: string; value: string; required?: boolean;
+  options: { value: string; label: string }[];
+  onChange: (value: string) => void;
+}) {
+  return (
+    <select
+      id={id}
+      name={name}
+      value={value}
+      required={required}
+      onChange={e => onChange(e.target.value)}
+      className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-[16px] md:text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+    >
+      {options.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+    </select>
+  );
+}
+
+interface AssetFormProps {
+  open: boolean;
+  asset?: Asset | null;
+  onClose: () => void;
+  onSubmit: (payload: AssetPayload) => Promise<void>;
+  onDelete?: (asset: Asset) => Promise<void>;
+}
+
+export function AssetForm({ open, asset, onClose, onSubmit, onDelete }: AssetFormProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [type, setType] = useState<AssetType>(asset?.type ?? "stock");
+  const [currency, setCurrency] = useState<Currency>(asset?.currency ?? "USD");
+
+  useEffect(() => {
+    if (!open) return;
+    setError("");
+    setConfirmDelete(false);
+    setType(asset?.type ?? "stock");
+    setCurrency(asset?.currency ?? "USD");
+  }, [open, asset]);
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+    const form = e.currentTarget;
+    const get = (name: string) => (form.elements.namedItem(name) as HTMLInputElement)?.value ?? "";
+
+    const metadata: Record<string, unknown> = {};
+    if (type === "real_estate") {
+      metadata.address = get("address");
+      metadata.purchasePrice = get("purchasePrice") ? Number(get("purchasePrice")) : undefined;
+      metadata.purchaseDate = get("purchaseDate") || undefined;
+    } else if (type === "stock") {
+      metadata.exchange = get("exchange");
+    } else if (type === "bond") {
+      metadata.issuer = get("issuer");
+      metadata.interestRate = get("interestRate") ? Number(get("interestRate")) : undefined;
+      metadata.maturityDate = get("maturityDate") || undefined;
+    } else if (type === "gold") {
+      metadata.form = get("goldForm");
+    }
+
+    const payload: AssetPayload = {
+      name: get("name"),
+      type,
+      currency,
+      currentValue: Number(get("currentValue")),
+      quantity: get("quantity") ? Number(get("quantity")) : null,
+      ticker: get("ticker") || null,
+      metadata,
+    };
+
+    try {
+      await onSubmit(payload);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const meta = asset?.metadata as Record<string, unknown> | undefined;
+
+  return (
+    <Dialog open={open} onOpenChange={next => !next && onClose()}>
+      <DialogContent className="w-[95vw] max-w-lg max-h-[90dvh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{asset ? "Edit Asset" : "Add Asset"}</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4 py-2">
+          <div className="space-y-2">
+            <Label htmlFor="name">Name</Label>
+            <Input id="name" name="name" placeholder="e.g. Apple shares" defaultValue={asset?.name ?? ""} required />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-2">
+              <Label htmlFor="type">Type</Label>
+              <NativeSelect id="type" name="type" value={type} onChange={v => setType(v as AssetType)}
+                options={ASSET_TYPE_OPTIONS} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="currency">Currency</Label>
+              <NativeSelect id="currency" name="currency" value={currency} onChange={v => setCurrency(v as Currency)}
+                options={CURRENCY_OPTIONS} />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-2">
+              <Label htmlFor="currentValue">Current Value</Label>
+              <Input id="currentValue" name="currentValue" type="number" step="any" min="0"
+                defaultValue={asset?.currentValue ?? ""} required />
+            </div>
+            {(type === "stock" || type === "gold") && (
+              <div className="space-y-2">
+                <Label htmlFor="quantity">{type === "gold" ? "Quantity (oz)" : "Shares"}</Label>
+                <Input id="quantity" name="quantity" type="number" step="any" min="0"
+                  defaultValue={asset?.quantity ?? ""} required />
+              </div>
+            )}
+          </div>
+
+          {type === "stock" && (
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-2">
+                <Label htmlFor="ticker">Ticker</Label>
+                <Input id="ticker" name="ticker" placeholder="e.g. AAPL"
+                  defaultValue={asset?.ticker ?? ""} required />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="exchange">Exchange</Label>
+                <Input id="exchange" name="exchange" placeholder="e.g. NASDAQ"
+                  defaultValue={meta?.exchange as string ?? ""} />
+              </div>
+            </div>
+          )}
+
+          {type === "real_estate" && (
+            <>
+              <div className="space-y-2">
+                <Label htmlFor="address">Address</Label>
+                <Input id="address" name="address" placeholder="e.g. 123 Main St"
+                  defaultValue={meta?.address as string ?? ""} />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-2">
+                  <Label htmlFor="purchasePrice">Purchase Price</Label>
+                  <Input id="purchasePrice" name="purchasePrice" type="number" step="any" min="0"
+                    defaultValue={meta?.purchasePrice as number ?? ""} />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="purchaseDate">Purchase Date</Label>
+                  <Input id="purchaseDate" name="purchaseDate" type="date"
+                    defaultValue={meta?.purchaseDate as string ?? ""} />
+                </div>
+              </div>
+            </>
+          )}
+
+          {type === "bond" && (
+            <>
+              <div className="space-y-2">
+                <Label htmlFor="issuer">Issuer</Label>
+                <Input id="issuer" name="issuer" placeholder="e.g. US Treasury"
+                  defaultValue={meta?.issuer as string ?? ""} />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-2">
+                  <Label htmlFor="interestRate">Interest Rate (%)</Label>
+                  <Input id="interestRate" name="interestRate" type="number" step="0.01" min="0"
+                    defaultValue={meta?.interestRate as number ?? ""} />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="maturityDate">Maturity Date</Label>
+                  <Input id="maturityDate" name="maturityDate" type="date"
+                    defaultValue={meta?.maturityDate as string ?? ""} />
+                </div>
+              </div>
+            </>
+          )}
+
+          {type === "gold" && (
+            <div className="space-y-2">
+              <Label htmlFor="goldForm">Form</Label>
+              <select
+                id="goldForm"
+                name="goldForm"
+                defaultValue={meta?.form as string ?? "physical"}
+                className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-[16px] md:text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                <option value="physical">Physical</option>
+                <option value="ETF">ETF</option>
+              </select>
+            </div>
+          )}
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+
+          <div className="flex items-center justify-between gap-2 pt-2">
+            <div>
+              {asset && onDelete && (
+                confirmDelete
+                  ? <p className="text-sm text-destructive">Delete this asset?</p>
+                  : <Button type="button" variant="outline"
+                      className="text-destructive hover:text-destructive border-destructive/40 hover:border-destructive"
+                      onClick={() => setConfirmDelete(true)} disabled={loading}>
+                      <Trash2 className="size-4 mr-1" />Delete
+                    </Button>
+              )}
+            </div>
+            <div className="flex gap-2">
+              {confirmDelete ? (
+                <>
+                  <Button type="button" variant="outline" onClick={() => setConfirmDelete(false)}>Cancel</Button>
+                  <Button type="button" variant="destructive" disabled={loading}
+                    onClick={async () => {
+                      setLoading(true);
+                      try { await onDelete?.(asset!); onClose(); }
+                      finally { setLoading(false); }
+                    }}>
+                    {loading ? "Deleting…" : "Confirm Delete"}
+                  </Button>
+                </>
+              ) : (
+                <>
+                  <Button type="button" variant="outline" onClick={onClose} disabled={loading}>Cancel</Button>
+                  <Button type="submit" disabled={loading}>{loading ? "Saving…" : asset ? "Save Changes" : "Add Asset"}</Button>
+                </>
+              )}
+            </div>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+pnpm exec tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/assets/asset-form.tsx
+git commit -m "feat: add asset form component"
+```
+
+---
+
+## Task 9: Asset Card Component
+
+**Files:**
+- Create: `components/assets/asset-card.tsx`
+
+- [ ] **Step 1: Create the file**
+
+```typescript
+"use client";
+
+import { RefreshCw, Pencil } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Asset } from "@/lib/api/assets";
+import { formatCurrency } from "@/lib/utils";
+
+const TYPE_LABELS: Record<string, string> = {
+  real_estate: "Real Estate",
+  stock: "Stock",
+  bond: "Bond",
+  gold: "Gold",
+};
+
+interface AssetCardProps {
+  asset: Asset;
+  onEdit: (asset: Asset) => void;
+  onRefreshPrice: (asset: Asset) => void;
+  refreshing?: boolean;
+}
+
+export function AssetCard({ asset, onEdit, onRefreshPrice, refreshing }: AssetCardProps) {
+  const canRefresh = asset.type === "stock" || asset.type === "gold";
+  const lastPriced = asset.lastPricedAt
+    ? new Date(asset.lastPricedAt).toLocaleDateString()
+    : null;
+
+  return (
+    <div className="flex items-center justify-between rounded-lg border p-3 gap-3">
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium truncate">{asset.name}</span>
+          <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[10px] text-muted-foreground">
+            {TYPE_LABELS[asset.type]}
+          </span>
+        </div>
+        <p className="text-base font-semibold mt-0.5">
+          {formatCurrency(asset.currentValue, asset.currency)}
+        </p>
+        {lastPriced && (
+          <p className="text-[10px] text-muted-foreground">Last priced: {lastPriced}</p>
+        )}
+      </div>
+      <div className="flex items-center gap-1 shrink-0">
+        {canRefresh && (
+          <Button size="icon" variant="ghost" className="size-8" onClick={() => onRefreshPrice(asset)} disabled={refreshing}>
+            <RefreshCw className={`size-4 ${refreshing ? "animate-spin" : ""}`} />
+          </Button>
+        )}
+        <Button size="icon" variant="ghost" className="size-8" onClick={() => onEdit(asset)}>
+          <Pencil className="size-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+pnpm exec tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/assets/asset-card.tsx
+git commit -m "feat: add asset card component"
+```
+
+---
+
+## Task 10: Assets Page
+
+**Files:**
+- Create: `app/assets/page.tsx`
+
+- [ ] **Step 1: Create the file**
+
+```typescript
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { AssetForm } from "@/components/assets/asset-form";
+import { AssetCard } from "@/components/assets/asset-card";
+import { createAsset, deleteAsset, getAssets, refreshAssetPrice, updateAsset, Asset, AssetType } from "@/lib/api/assets";
+import { formatCurrency } from "@/lib/utils";
+
+const TYPE_ORDER: AssetType[] = ["real_estate", "stock", "bond", "gold"];
+const TYPE_LABELS: Record<AssetType, string> = {
+  real_estate: "Real Estate",
+  stock: "Stocks",
+  bond: "Bonds",
+  gold: "Gold",
+};
+
+export default function AssetsPage() {
+  const queryClient = useQueryClient();
+  const [formOpen, setFormOpen] = useState(false);
+  const [editingAsset, setEditingAsset] = useState<Asset | null>(null);
+  const [refreshingId, setRefreshingId] = useState<string | null>(null);
+
+  const { data: assets = [], isLoading, error } = useQuery({
+    queryKey: ["assets"],
+    queryFn: getAssets,
+  });
+
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: ["assets"] });
+
+  const createMutation = useMutation({ mutationFn: createAsset, onSuccess: invalidate });
+  const updateMutation = useMutation({
+    mutationFn: ({ id, ...p }: { id: string } & Parameters<typeof updateAsset>[1]) => updateAsset(id, p),
+    onSuccess: invalidate,
+  });
+  const deleteMutation = useMutation({ mutationFn: deleteAsset, onSuccess: invalidate });
+
+  async function handleRefreshPrice(asset: Asset) {
+    setRefreshingId(asset.id);
+    try {
+      await refreshAssetPrice(asset.id);
+      invalidate();
+    } finally {
+      setRefreshingId(null);
+    }
+  }
+
+  const totalValue = assets.reduce((sum, a) => sum + a.currentValue, 0);
+
+  const byType = TYPE_ORDER.reduce((acc, t) => {
+    acc[t] = assets.filter(a => a.type === t);
+    return acc;
+  }, {} as Record<AssetType, Asset[]>);
+
+  return (
+    <main className="max-w-lg mx-auto px-4 py-8 pb-24">
+      <div className="mb-6 flex items-start justify-between">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-semibold">Assets</h1>
+          {assets.length > 0 && (
+            <p className="text-sm text-muted-foreground">
+              Total: {formatCurrency(totalValue, "USD")}
+            </p>
+          )}
+        </div>
+        <Button size="sm" onClick={() => { setEditingAsset(null); setFormOpen(true); }}>
+          <Plus className="size-4 mr-1" />Add Asset
+        </Button>
+      </div>
+
+      {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+      {!isLoading && error && <p className="text-sm text-destructive">Unable to load assets.</p>}
+
+      {!isLoading && !error && assets.length === 0 && (
+        <div className="rounded-lg border p-4 space-y-1">
+          <p className="text-sm font-medium">No assets yet</p>
+          <p className="text-sm text-muted-foreground">Add real estate, stocks, bonds, or gold to track your wealth.</p>
+        </div>
+      )}
+
+      {!isLoading && !error && assets.length > 0 && (
+        <div className="space-y-6">
+          {TYPE_ORDER.map(type => {
+            const items = byType[type];
+            if (items.length === 0) return null;
+            return (
+              <div key={type}>
+                <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+                  {TYPE_LABELS[type]}
+                </h2>
+                <div className="space-y-2">
+                  {items.map(asset => (
+                    <AssetCard
+                      key={asset.id}
+                      asset={asset}
+                      onEdit={a => { setEditingAsset(a); setFormOpen(true); }}
+                      onRefreshPrice={handleRefreshPrice}
+                      refreshing={refreshingId === asset.id}
+                    />
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <AssetForm
+        open={formOpen}
+        asset={editingAsset}
+        onClose={() => { setFormOpen(false); setEditingAsset(null); }}
+        onSubmit={async payload => {
+          if (editingAsset) {
+            await updateMutation.mutateAsync({ id: editingAsset.id, ...payload });
+          } else {
+            await createMutation.mutateAsync(payload);
+          }
+        }}
+        onDelete={async asset => { await deleteMutation.mutateAsync(asset.id); }}
+      />
+    </main>
+  );
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+pnpm exec tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/assets/page.tsx
+git commit -m "feat: add assets page"
+```
+
+---
+
+## Task 11: Net Worth Page
+
+**Files:**
+- Create: `app/networth/page.tsx`
+
+- [ ] **Step 1: Create the file**
+
+```typescript
+"use client";
+
+import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+import { ArrowRight, AlertTriangle } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { getNetWorth, NetWorthResponse, AssetItem, AccountItem, LoanItem } from "@/lib/api/networth";
+import { formatCurrency } from "@/lib/utils";
+
+const ASSET_TYPE_LABELS: Record<string, string> = {
+  real_estate: "Real Estate",
+  stock: "Stocks",
+  bond: "Bonds",
+  gold: "Gold",
+};
+
+function SectionCard({ title, total, children, href }: {
+  title: string; total: number; children: React.ReactNode; href?: string;
+}) {
+  return (
+    <div className="rounded-lg border">
+      <div className="flex items-center justify-between px-4 py-3 border-b">
+        <h2 className="text-sm font-semibold">{title}</h2>
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-semibold">{formatCurrency(total, "USD")}</span>
+          {href && (
+            <Link href={href} className="text-muted-foreground hover:text-foreground">
+              <ArrowRight className="size-4" />
+            </Link>
+          )}
+        </div>
+      </div>
+      <div className="divide-y">{children}</div>
+    </div>
+  );
+}
+
+function Row({ label, value, sub }: { label: string; value: number; sub?: string }) {
+  return (
+    <div className="flex items-center justify-between px-4 py-2">
+      <div>
+        <p className="text-sm">{label}</p>
+        {sub && <p className="text-[10px] text-muted-foreground">{sub}</p>}
+      </div>
+      <p className="text-sm font-medium">{formatCurrency(value, "USD")}</p>
+    </div>
+  );
+}
+
+function AssetsBreakdown({ data }: { data: NetWorthResponse["assets"] }) {
+  return (
+    <>
+      {(Object.entries(data.byType) as [string, { total: number; items: AssetItem[] }][])
+        .filter(([, v]) => v.items.length > 0)
+        .map(([type, group]) => (
+          <div key={type}>
+            <div className="flex items-center justify-between px-4 py-2 bg-muted/30">
+              <p className="text-xs font-medium text-muted-foreground">{ASSET_TYPE_LABELS[type]}</p>
+              <p className="text-xs font-medium text-muted-foreground">{formatCurrency(group.total, "USD")}</p>
+            </div>
+            {group.items.map(item => (
+              <Row key={item.id} label={item.name} value={item.valueInUsd}
+                sub={item.ticker ? `${item.ticker} · ${item.currentValue} @ qty ${item.quantity}` : undefined} />
+            ))}
+          </div>
+        ))}
+    </>
+  );
+}
+
+export default function NetWorthPage() {
+  const { data, isLoading, error } = useQuery<NetWorthResponse>({
+    queryKey: ["networth"],
+    queryFn: getNetWorth,
+  });
+
+  return (
+    <main className="max-w-lg mx-auto px-4 py-8 pb-24">
+      <h1 className="text-2xl font-semibold mb-6">Net Worth</h1>
+
+      {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+      {!isLoading && error && <p className="text-sm text-destructive">Unable to load net worth.</p>}
+
+      {data && (
+        <div className="space-y-4">
+          <Card>
+            <CardContent className="py-4 px-4">
+              <p className="text-xs text-muted-foreground">Total Net Worth</p>
+              <p className={`text-3xl font-bold tracking-tight mt-1 ${data.totalNetWorth >= 0 ? "" : "text-destructive"}`}>
+                {formatCurrency(data.totalNetWorth, "USD")}
+              </p>
+              <div className="mt-3 grid grid-cols-3 gap-2 text-center">
+                <div>
+                  <p className="text-[10px] text-muted-foreground">Liquid</p>
+                  <p className="text-sm font-semibold text-green-600 dark:text-green-400">{formatCurrency(data.liquid.total, "USD")}</p>
+                </div>
+                <div>
+                  <p className="text-[10px] text-muted-foreground">Assets</p>
+                  <p className="text-sm font-semibold text-blue-600 dark:text-blue-400">{formatCurrency(data.assets.total, "USD")}</p>
+                </div>
+                <div>
+                  <p className="text-[10px] text-muted-foreground">Liabilities</p>
+                  <p className="text-sm font-semibold text-red-600 dark:text-red-400">{formatCurrency(data.liabilities.total, "USD")}</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {data.missingRates.length > 0 && (
+            <div className="flex items-start gap-2 rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-sm text-yellow-700 dark:text-yellow-400">
+              <AlertTriangle className="size-4 mt-0.5 shrink-0" />
+              <span>Missing exchange rates for: {data.missingRates.join(", ")}. Some values shown unconverted.</span>
+            </div>
+          )}
+
+          <SectionCard title="Liquid" total={data.liquid.total} href="/settings/accounts">
+            {data.liquid.accounts.map((a: AccountItem) => (
+              <Row key={a.id} label={a.name} value={a.valueInUsd}
+                sub={a.currency !== "USD" ? `${formatCurrency(a.balance, a.currency)}` : undefined} />
+            ))}
+          </SectionCard>
+
+          {data.assets.total > 0 && (
+            <SectionCard title="Assets" total={data.assets.total} href="/assets">
+              <AssetsBreakdown data={data.assets} />
+            </SectionCard>
+          )}
+
+          {data.liabilities.total > 0 && (
+            <SectionCard title="Liabilities" total={data.liabilities.total} href="/loans">
+              {data.liabilities.loans.map((l: LoanItem) => (
+                <Row key={l.id} label={l.name} value={l.valueInUsd}
+                  sub={l.currency !== "USD" ? `${formatCurrency(l.outstandingPrincipal, l.currency)} outstanding` : "outstanding"} />
+              ))}
+            </SectionCard>
+          )}
+        </div>
+      )}
+    </main>
+  );
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+pnpm exec tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/networth/page.tsx
+git commit -m "feat: add net worth page"
+```
+
+---
+
+## Task 12: Bottom Nav Update
+
+**Files:**
+- Modify: `components/bottom-nav.tsx`
+
+> **Note:** This adds Net Worth and Assets to the nav for a total of 7 items. If the nav feels too crowded, consider removing Loans (accessible via Settings) in a follow-up.
+
+- [ ] **Step 1: Update the nav items**
+
+Replace the `NAV_ITEMS` array and imports in `components/bottom-nav.tsx`:
+
+```typescript
+import { Building2, HandCoins, Home, List, PiggyBank, Settings, TrendingUp } from "lucide-react";
+
+const NAV_ITEMS = [
+  { href: "/", label: "Home", icon: Home },
+  { href: "/transactions", label: "Transactions", icon: List },
+  { href: "/budgets", label: "Budgets", icon: PiggyBank },
+  { href: "/networth", label: "Net Worth", icon: TrendingUp },
+  { href: "/assets", label: "Assets", icon: Building2 },
+  { href: "/loans", label: "Loans", icon: HandCoins },
+  { href: "/settings", label: "Settings", icon: Settings },
+];
+```
+
+- [ ] **Step 2: Type-check and lint**
+
+```bash
+pnpm exec tsc --noEmit && pnpm exec eslint components/bottom-nav.tsx
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Start dev server and verify navigation**
+
+```bash
+pnpm dev
+```
+
+Open http://localhost:3000, verify:
+- Net Worth and Assets appear in the bottom nav
+- Navigating to `/networth` shows the net worth page
+- Navigating to `/assets` shows the assets list
+- Add an asset, verify it appears in the list and in the net worth page
+- Refresh price on a stock (e.g. ticker "AAPL") and verify currentValue updates
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/bottom-nav.tsx
+git commit -m "feat: add net worth and assets to bottom nav"
+```

--- a/docs/superpowers/plans/2026-05-11-default-currency.md
+++ b/docs/superpowers/plans/2026-05-11-default-currency.md
@@ -1,0 +1,919 @@
+# Default Display Currency Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users set a preferred display currency so all monetary summaries (home dashboard, net worth) convert values to it.
+
+**Architecture:** `defaultCurrency` is stored in `UserSettings`. The `/api/networth` endpoint reads it server-side and converts all values before responding. The home page reads the setting via an existing React Query fetch and uses it as the conversion target for client-side total balance calculation.
+
+**Tech Stack:** Next.js App Router, Prisma (PostgreSQL), React Query, shadcn/ui
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Modify | `prisma/schema.prisma` | Add `defaultCurrency` field to `UserSettings` |
+| Modify | `app/api/settings/route.ts` | Allow `defaultCurrency` in PUT |
+| Modify | `lib/api/settings.ts` | Add `defaultCurrency` to client types |
+| Modify | `app/api/networth/route.ts` | Read `defaultCurrency`, convert server-side, return `currency` in response |
+| Modify | `lib/api/networth.ts` | Add `currency` field to `NetWorthResponse` |
+| Modify | `app/networth/page.tsx` | Use `data.currency` instead of hardcoded `"USD"` |
+| Modify | `app/page.tsx` | Fetch settings, use `defaultCurrency` as display currency |
+| Modify | `app/settings/page.tsx` | Add inline currency selector |
+
+---
+
+## Task 1: Prisma Schema — Add `defaultCurrency` to `UserSettings`
+
+**Files:**
+- Modify: `prisma/schema.prisma`
+
+- [ ] **Step 1: Add the field**
+
+In `prisma/schema.prisma`, add `defaultCurrency` to the `UserSettings` model after the existing `userId` fields:
+
+```prisma
+model UserSettings {
+  id                              String   @id @default(cuid())
+  userId                          String   @unique
+  user                            User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  defaultCurrency                 Currency @default(USD)
+  loanBorrowedInitialCategoryId   String?
+  loanBorrowedPrincipalCategoryId String?
+  loanBorrowedInterestCategoryId  String?
+  loanBorrowedPrepayFeeCategoryId String?
+  loanLentInitialCategoryId       String?
+  loanLentPrincipalCategoryId     String?
+  loanLentInterestCategoryId      String?
+  loanLentPrepayFeeCategoryId     String?
+  createdAt                       DateTime @default(now())
+  updatedAt                       DateTime @updatedAt
+}
+```
+
+- [ ] **Step 2: Run migration**
+
+```bash
+pnpm prisma migrate dev --name add-default-currency
+```
+
+Expected: migration file created, Prisma client regenerated, no errors.
+
+- [ ] **Step 3: Type-check**
+
+```bash
+pnpm exec tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add prisma/schema.prisma prisma/migrations/
+git commit -m "feat: add defaultCurrency to UserSettings"
+```
+
+---
+
+## Task 2: Settings API — Allow `defaultCurrency` in PUT
+
+**Files:**
+- Modify: `app/api/settings/route.ts`
+
+- [ ] **Step 1: Add `defaultCurrency` to the allowed fields list**
+
+In `app/api/settings/route.ts`, update the `allowed` array:
+
+```typescript
+const allowed = [
+  "defaultCurrency",
+  "loanBorrowedInitialCategoryId",
+  "loanBorrowedPrincipalCategoryId",
+  "loanBorrowedInterestCategoryId",
+  "loanBorrowedPrepayFeeCategoryId",
+  "loanLentInitialCategoryId",
+  "loanLentPrincipalCategoryId",
+  "loanLentInterestCategoryId",
+  "loanLentPrepayFeeCategoryId",
+] as const;
+```
+
+Also update the `data` type to accept `Currency` values, not just `string | null`:
+
+```typescript
+const data: Record<string, string | null> = {};
+for (const key of allowed) {
+  if (key in body) {
+    data[key] = body[key] || null;
+  }
+}
+```
+
+This already works for `defaultCurrency` since Prisma will validate the enum value. No additional change needed.
+
+- [ ] **Step 2: Type-check**
+
+```bash
+pnpm exec tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/api/settings/route.ts
+git commit -m "feat: allow defaultCurrency in settings API"
+```
+
+---
+
+## Task 3: Settings Client Types
+
+**Files:**
+- Modify: `lib/api/settings.ts`
+
+- [ ] **Step 1: Add `defaultCurrency` to the `UserSettings` interface and payload**
+
+Replace the existing content of `lib/api/settings.ts`:
+
+```typescript
+import api from "@/lib/axios";
+import { Currency } from "./accounts";
+
+export interface UserSettings {
+  id: string;
+  userId: string;
+  defaultCurrency: Currency;
+  loanBorrowedInitialCategoryId: string | null;
+  loanBorrowedPrincipalCategoryId: string | null;
+  loanBorrowedInterestCategoryId: string | null;
+  loanBorrowedPrepayFeeCategoryId: string | null;
+  loanLentInitialCategoryId: string | null;
+  loanLentPrincipalCategoryId: string | null;
+  loanLentInterestCategoryId: string | null;
+  loanLentPrepayFeeCategoryId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type UserSettingsPayload = Partial<Pick<
+  UserSettings,
+  | "defaultCurrency"
+  | "loanBorrowedInitialCategoryId"
+  | "loanBorrowedPrincipalCategoryId"
+  | "loanBorrowedInterestCategoryId"
+  | "loanBorrowedPrepayFeeCategoryId"
+  | "loanLentInitialCategoryId"
+  | "loanLentPrincipalCategoryId"
+  | "loanLentInterestCategoryId"
+  | "loanLentPrepayFeeCategoryId"
+>>;
+
+export async function getSettings(): Promise<UserSettings> {
+  const { data } = await api.get<UserSettings>("/settings");
+  return data;
+}
+
+export async function updateSettings(payload: UserSettingsPayload): Promise<UserSettings> {
+  const { data } = await api.put<UserSettings>("/settings", payload);
+  return data;
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+pnpm exec tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/api/settings.ts
+git commit -m "feat: add defaultCurrency to settings client types"
+```
+
+---
+
+## Task 4: Net Worth API — Server-side Conversion with `defaultCurrency`
+
+**Files:**
+- Modify: `app/api/networth/route.ts`
+
+- [ ] **Step 1: Replace the file contents**
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/app/lib/db";
+import { getSession } from "@/app/lib/auth";
+import { Currency } from "@prisma/client";
+
+function convertToCurrency(
+  amount: number,
+  fromCurrency: Currency,
+  toCurrency: Currency,
+  rates: { fromCurrency: string; toCurrency: string; rate: number }[]
+): number {
+  if (fromCurrency === toCurrency) return amount;
+  const direct = rates.find(r => r.fromCurrency === fromCurrency && r.toCurrency === toCurrency);
+  if (direct) return amount * direct.rate;
+  const inverse = rates.find(r => r.fromCurrency === toCurrency && r.toCurrency === fromCurrency);
+  if (inverse) return amount / inverse.rate;
+  return amount;
+}
+
+export async function GET(req: NextRequest) {
+  const session = await getSession(req);
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const [settings, accounts, assets, loans, exchangeRates] = await Promise.all([
+    prisma.userSettings.upsert({
+      where: { userId: session.userId },
+      create: { userId: session.userId },
+      update: {},
+    }),
+    prisma.account.findMany({ where: { userId: session.userId } }),
+    prisma.asset.findMany({ where: { userId: session.userId } }),
+    prisma.loan.findMany({
+      where: { userId: session.userId, status: "active" },
+      include: {
+        initialTransaction: { select: { amount: true } },
+        payments: {
+          include: {
+            principalTransaction: { select: { amount: true } },
+          },
+        },
+      },
+    }),
+    prisma.exchangeRate.findMany({ where: { userId: session.userId } }),
+  ]);
+
+  const targetCurrency = settings.defaultCurrency;
+  const missingRates: string[] = [];
+
+  function convert(amount: number, fromCurrency: Currency): number {
+    const result = convertToCurrency(amount, fromCurrency, targetCurrency, exchangeRates);
+    if (fromCurrency !== targetCurrency && result === amount) {
+      missingRates.push(`${fromCurrency}/${targetCurrency}`);
+    }
+    return result;
+  }
+
+  const accountItems = accounts.map(a => ({
+    id: a.id,
+    name: a.name,
+    balance: a.balance,
+    currency: a.currency,
+    valueInTarget: convert(a.balance, a.currency),
+  }));
+
+  const assetItems = assets.map(a => ({
+    ...a,
+    valueInTarget: convert(a.currentValue, a.currency),
+  }));
+
+  const loanItems = loans.map(loan => {
+    const principalAmount = loan.initialTransaction?.amount ?? 0;
+    const paidPrincipal = loan.payments.reduce((sum, p) => sum + (p.principalTransaction?.amount ?? 0), 0);
+    const outstandingPrincipal = Math.max(0, principalAmount - paidPrincipal);
+    return {
+      id: loan.id,
+      name: loan.name,
+      direction: loan.direction,
+      outstandingPrincipal,
+      currency: loan.currency,
+      valueInTarget: convert(outstandingPrincipal, loan.currency),
+    };
+  });
+
+  const borrowedLoans = loanItems.filter(l => l.direction === "borrowed");
+
+  const liquidTotal = accountItems.reduce((s, a) => s + a.valueInTarget, 0);
+  const assetsByType = {
+    real_estate: assetItems.filter(a => a.type === "real_estate"),
+    stock: assetItems.filter(a => a.type === "stock"),
+    bond: assetItems.filter(a => a.type === "bond"),
+    gold: assetItems.filter(a => a.type === "gold"),
+  };
+  const assetsTotal = assetItems.reduce((s, a) => s + a.valueInTarget, 0);
+  const liabilitiesTotal = borrowedLoans.reduce((s, l) => s + l.valueInTarget, 0);
+
+  return NextResponse.json({
+    currency: targetCurrency,
+    totalNetWorth: liquidTotal + assetsTotal - liabilitiesTotal,
+    missingRates: [...new Set(missingRates)],
+    liquid: { total: liquidTotal, accounts: accountItems },
+    assets: {
+      total: assetsTotal,
+      byType: {
+        real_estate: { total: assetsByType.real_estate.reduce((s, a) => s + a.valueInTarget, 0), items: assetsByType.real_estate },
+        stock: { total: assetsByType.stock.reduce((s, a) => s + a.valueInTarget, 0), items: assetsByType.stock },
+        bond: { total: assetsByType.bond.reduce((s, a) => s + a.valueInTarget, 0), items: assetsByType.bond },
+        gold: { total: assetsByType.gold.reduce((s, a) => s + a.valueInTarget, 0), items: assetsByType.gold },
+      },
+    },
+    liabilities: { total: liabilitiesTotal, loans: borrowedLoans },
+  });
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+pnpm exec tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/api/networth/route.ts
+git commit -m "feat: use defaultCurrency in net worth API"
+```
+
+---
+
+## Task 5: Net Worth Client Types — Add `currency` to Response
+
+**Files:**
+- Modify: `lib/api/networth.ts`
+
+- [ ] **Step 1: Update `AccountItem`, `AssetItem`, `LoanItem` and `NetWorthResponse`**
+
+The API now returns `valueInTarget` instead of `valueInUsd`. Update `lib/api/networth.ts`:
+
+```typescript
+import api from "@/lib/axios";
+import { Currency } from "./accounts";
+import { AssetType } from "./assets";
+
+export interface AccountItem {
+  id: string;
+  name: string;
+  balance: number;
+  currency: Currency;
+  valueInTarget: number;
+}
+
+export interface AssetItem {
+  id: string;
+  name: string;
+  type: AssetType;
+  currency: Currency;
+  currentValue: number;
+  quantity: number | null;
+  ticker: string | null;
+  lastPricedAt: string | null;
+  valueInTarget: number;
+}
+
+export interface LoanItem {
+  id: string;
+  name: string;
+  direction: "borrowed" | "lent";
+  outstandingPrincipal: number;
+  currency: Currency;
+  valueInTarget: number;
+}
+
+export interface AssetsByType {
+  real_estate: { total: number; items: AssetItem[] };
+  stock: { total: number; items: AssetItem[] };
+  bond: { total: number; items: AssetItem[] };
+  gold: { total: number; items: AssetItem[] };
+}
+
+export interface NetWorthResponse {
+  currency: Currency;
+  totalNetWorth: number;
+  missingRates: string[];
+  liquid: { total: number; accounts: AccountItem[] };
+  assets: { total: number; byType: AssetsByType };
+  liabilities: { total: number; loans: LoanItem[] };
+}
+
+export async function getNetWorth(): Promise<NetWorthResponse> {
+  const { data } = await api.get<NetWorthResponse>("/networth");
+  return data;
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+pnpm exec tsc --noEmit
+```
+
+Expected: type errors in `app/networth/page.tsx` referencing old `valueInUsd` field — these get fixed in the next task.
+
+- [ ] **Step 3: Commit after next task passes type-check** (skip this commit, continue to Task 6)
+
+---
+
+## Task 6: Net Worth Page — Use `data.currency` and `valueInTarget`
+
+**Files:**
+- Modify: `app/networth/page.tsx`
+
+- [ ] **Step 1: Replace `valueInUsd` with `valueInTarget` and `"USD"` with `data.currency`**
+
+Update `app/networth/page.tsx`. The changes are:
+
+1. `Row` now receives `currency` prop for formatting
+2. All `valueInUsd` references become `valueInTarget`
+3. All hardcoded `"USD"` in `formatCurrency` calls become the response `currency`
+
+Replace the full file:
+
+```typescript
+"use client";
+
+import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+import { AlertTriangle, ArrowRight } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  getNetWorth,
+  NetWorthResponse,
+  AssetItem,
+  AccountItem,
+  LoanItem,
+} from "@/lib/api/networth";
+import { formatCurrency } from "@/lib/utils";
+import { Currency } from "@/lib/api/accounts";
+
+const ASSET_TYPE_LABELS: Record<string, string> = {
+  real_estate: "Real Estate",
+  stock: "Stocks",
+  bond: "Bonds",
+  gold: "Gold",
+};
+
+function SectionCard({
+  title,
+  total,
+  currency,
+  children,
+  href,
+}: {
+  title: string;
+  total: number;
+  currency: Currency;
+  children: React.ReactNode;
+  href?: string;
+}) {
+  return (
+    <div className="rounded-lg border">
+      <div className="flex items-center justify-between px-4 py-3 border-b">
+        <h2 className="text-sm font-semibold">{title}</h2>
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-semibold">{formatCurrency(total, currency)}</span>
+          {href && (
+            <Link href={href} className="text-muted-foreground hover:text-foreground">
+              <ArrowRight className="size-4" />
+            </Link>
+          )}
+        </div>
+      </div>
+      <div className="divide-y">{children}</div>
+    </div>
+  );
+}
+
+function Row({
+  label,
+  value,
+  currency,
+  sub,
+}: {
+  label: string;
+  value: number;
+  currency: Currency;
+  sub?: string;
+}) {
+  return (
+    <div className="flex items-center justify-between px-4 py-2">
+      <div>
+        <p className="text-sm">{label}</p>
+        {sub && <p className="text-[10px] text-muted-foreground">{sub}</p>}
+      </div>
+      <p className="text-sm font-medium">{formatCurrency(value, currency)}</p>
+    </div>
+  );
+}
+
+function AssetsBreakdown({
+  data,
+  currency,
+}: {
+  data: NetWorthResponse["assets"];
+  currency: Currency;
+}) {
+  return (
+    <>
+      {(
+        Object.entries(data.byType) as [
+          string,
+          { total: number; items: AssetItem[] },
+        ][]
+      )
+        .filter(([, v]) => v.items.length > 0)
+        .map(([type, group]) => (
+          <div key={type}>
+            <div className="flex items-center justify-between px-4 py-2 bg-muted/30">
+              <p className="text-xs font-medium text-muted-foreground">
+                {ASSET_TYPE_LABELS[type]}
+              </p>
+              <p className="text-xs font-medium text-muted-foreground">
+                {formatCurrency(group.total, currency)}
+              </p>
+            </div>
+            {group.items.map(item => (
+              <Row
+                key={item.id}
+                label={item.name}
+                value={item.valueInTarget}
+                currency={currency}
+                sub={
+                  item.ticker
+                    ? `${item.ticker} · qty ${item.quantity}`
+                    : undefined
+                }
+              />
+            ))}
+          </div>
+        ))}
+    </>
+  );
+}
+
+export default function NetWorthPage() {
+  const { data, isLoading, error } = useQuery<NetWorthResponse>({
+    queryKey: ["networth"],
+    queryFn: getNetWorth,
+  });
+
+  const currency = data?.currency ?? "USD";
+
+  return (
+    <main className="max-w-lg mx-auto px-4 py-8 pb-24">
+      <h1 className="text-2xl font-semibold mb-6">Net Worth</h1>
+
+      {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+      {!isLoading && error && (
+        <p className="text-sm text-destructive">Unable to load net worth.</p>
+      )}
+
+      {data && (
+        <div className="space-y-4">
+          <Card>
+            <CardContent className="py-4 px-4">
+              <p className="text-xs text-muted-foreground">Total Net Worth</p>
+              <p
+                className={`text-3xl font-bold tracking-tight mt-1 ${
+                  data.totalNetWorth >= 0 ? "" : "text-destructive"
+                }`}
+              >
+                {formatCurrency(data.totalNetWorth, currency)}
+              </p>
+              <div className="mt-3 grid grid-cols-3 gap-2 text-center">
+                <div>
+                  <p className="text-[10px] text-muted-foreground">Liquid</p>
+                  <p className="text-sm font-semibold text-green-600 dark:text-green-400">
+                    {formatCurrency(data.liquid.total, currency)}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-[10px] text-muted-foreground">Assets</p>
+                  <p className="text-sm font-semibold text-blue-600 dark:text-blue-400">
+                    {formatCurrency(data.assets.total, currency)}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-[10px] text-muted-foreground">Liabilities</p>
+                  <p className="text-sm font-semibold text-red-600 dark:text-red-400">
+                    {formatCurrency(data.liabilities.total, currency)}
+                  </p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {data.missingRates.length > 0 && (
+            <div className="flex items-start gap-2 rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-sm text-yellow-700 dark:text-yellow-400">
+              <AlertTriangle className="size-4 mt-0.5 shrink-0" />
+              <span>
+                Missing exchange rates for: {data.missingRates.join(", ")}. Some
+                values shown unconverted.
+              </span>
+            </div>
+          )}
+
+          <SectionCard
+            title="Liquid"
+            total={data.liquid.total}
+            currency={currency}
+            href="/settings/accounts"
+          >
+            {data.liquid.accounts.map((a: AccountItem) => (
+              <Row
+                key={a.id}
+                label={a.name}
+                value={a.valueInTarget}
+                currency={currency}
+                sub={
+                  a.currency !== currency
+                    ? formatCurrency(a.balance, a.currency)
+                    : undefined
+                }
+              />
+            ))}
+          </SectionCard>
+
+          {data.assets.total > 0 && (
+            <SectionCard
+              title="Assets"
+              total={data.assets.total}
+              currency={currency}
+              href="/assets"
+            >
+              <AssetsBreakdown data={data.assets} currency={currency} />
+            </SectionCard>
+          )}
+
+          {data.liabilities.total > 0 && (
+            <SectionCard
+              title="Liabilities"
+              total={data.liabilities.total}
+              currency={currency}
+              href="/loans"
+            >
+              {data.liabilities.loans.map((l: LoanItem) => (
+                <Row
+                  key={l.id}
+                  label={l.name}
+                  value={l.valueInTarget}
+                  currency={currency}
+                  sub={
+                    l.currency !== currency
+                      ? `${formatCurrency(l.outstandingPrincipal, l.currency)} outstanding`
+                      : "outstanding"
+                  }
+                />
+              ))}
+            </SectionCard>
+          )}
+        </div>
+      )}
+    </main>
+  );
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+pnpm exec tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit Tasks 5 and 6 together**
+
+```bash
+git add lib/api/networth.ts app/networth/page.tsx
+git commit -m "feat: use defaultCurrency in net worth client and page"
+```
+
+---
+
+## Task 7: Home Page — Use `defaultCurrency` from Settings
+
+**Files:**
+- Modify: `app/page.tsx`
+
+- [ ] **Step 1: Import `getSettings` and add the settings query**
+
+In `app/page.tsx`, add the import and query:
+
+```typescript
+// Add to existing imports:
+import { getSettings } from "@/lib/api/settings";
+```
+
+Inside the `Home` component, add after the existing queries:
+
+```typescript
+const { data: settings } = useQuery({
+  queryKey: ["settings"],
+  queryFn: getSettings,
+});
+```
+
+- [ ] **Step 2: Replace the derived `currency` line**
+
+Find and replace:
+
+```typescript
+// Use default account's currency or fallback to USD
+const defaultAccount = accounts.find(acc => acc.isDefault);
+const currency = defaultAccount?.currency ?? accounts[0]?.currency ?? "USD";
+```
+
+With:
+
+```typescript
+const currency = (settings?.defaultCurrency ?? "USD") as Currency;
+```
+
+The `defaultAccount` variable is no longer needed for currency. Remove the `defaultAccount` declaration as well (it was only used for currency derivation — verify it isn't used elsewhere in the component before removing).
+
+- [ ] **Step 3: Type-check**
+
+```bash
+pnpm exec tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/page.tsx
+git commit -m "feat: use defaultCurrency from settings on home page"
+```
+
+---
+
+## Task 8: Settings Page — Inline Currency Selector
+
+**Files:**
+- Modify: `app/settings/page.tsx`
+
+- [ ] **Step 1: Replace the file with the updated version**
+
+```typescript
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ChevronRight, CreditCard, Tag, User, DollarSign, Upload, Landmark } from "lucide-react";
+import { ImportDialog } from "@/components/transactions/import-dialog";
+import { getSettings, updateSettings } from "@/lib/api/settings";
+import { Currency } from "@/lib/api/accounts";
+
+const SETTINGS_ITEMS = [
+  { href: "/settings/account", label: "User", description: "Manage password and logout", icon: User },
+  { href: "/settings/accounts", label: "Accounts", description: "Manage your bank accounts", icon: CreditCard },
+  { href: "/settings/categories", label: "Categories", description: "Manage transaction categories", icon: Tag },
+  { href: "/settings/exchange-rates", label: "Currency", description: "Manage exchange rates", icon: DollarSign },
+  { href: "/settings/loan-categories", label: "Loan Defaults", description: "Default categories for loan payments", icon: Landmark },
+];
+
+const CURRENCY_OPTIONS: { value: Currency; label: string }[] = [
+  { value: "USD", label: "USD" },
+  { value: "VND", label: "VND" },
+];
+
+export default function SettingsPage() {
+  const [importOpen, setImportOpen] = useState(false);
+  const queryClient = useQueryClient();
+
+  const { data: settings } = useQuery({
+    queryKey: ["settings"],
+    queryFn: getSettings,
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: updateSettings,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["settings"] });
+      queryClient.invalidateQueries({ queryKey: ["networth"] });
+    },
+  });
+
+  return (
+    <main className="max-w-lg mx-auto px-4 py-8">
+      <div className="mb-4 rounded-lg border px-4 py-3 flex items-center justify-between">
+        <div>
+          <p className="text-sm font-medium">Display Currency</p>
+          <p className="text-xs text-muted-foreground">Used for summaries and net worth</p>
+        </div>
+        <select
+          value={settings?.defaultCurrency ?? "USD"}
+          onChange={e =>
+            updateMutation.mutate({ defaultCurrency: e.target.value as Currency })
+          }
+          className="h-9 rounded-md border border-input bg-transparent px-3 py-1 text-[16px] md:text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        >
+          {CURRENCY_OPTIONS.map(o => (
+            <option key={o.value} value={o.value}>{o.label}</option>
+          ))}
+        </select>
+      </div>
+
+      <div className="divide-y rounded-lg border overflow-hidden">
+        {SETTINGS_ITEMS.map(({ href, label, description, icon: Icon }) => (
+          <Link
+            key={href}
+            href={href}
+            className="flex items-center gap-4 px-4 py-4 hover:bg-accent transition-colors"
+          >
+            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-primary/10 shrink-0">
+              <Icon className="size-4 text-primary" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="font-medium text-sm">{label}</p>
+              <p className="text-xs text-muted-foreground">{description}</p>
+            </div>
+            <ChevronRight className="size-4 text-muted-foreground shrink-0" />
+          </Link>
+        ))}
+        <button
+          onClick={() => setImportOpen(true)}
+          className="flex w-full items-center gap-4 px-4 py-4 hover:bg-accent transition-colors"
+        >
+          <div className="flex h-9 w-9 items-center justify-center rounded-full bg-primary/10 shrink-0">
+            <Upload className="size-4 text-primary" />
+          </div>
+          <div className="flex-1 min-w-0 text-left">
+            <p className="font-medium text-sm">Import</p>
+            <p className="text-xs text-muted-foreground">Import transactions from a file</p>
+          </div>
+          <ChevronRight className="size-4 text-muted-foreground shrink-0" />
+        </button>
+      </div>
+
+      <ImportDialog open={importOpen} onClose={() => setImportOpen(false)} />
+    </main>
+  );
+}
+```
+
+- [ ] **Step 2: Type-check and lint**
+
+```bash
+pnpm exec tsc --noEmit && pnpm exec eslint app/settings/page.tsx
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/settings/page.tsx
+git commit -m "feat: add display currency selector to settings page"
+```
+
+---
+
+## Task 9: Update Seed to Clear `UserSettings` on Re-seed
+
+**Files:**
+- Modify: `prisma/seed.ts`
+
+- [ ] **Step 1: Add `userSettings` cleanup before user deletion**
+
+In `prisma/seed.ts`, add this line before `prisma.user.deleteMany`:
+
+```typescript
+await prisma.userSettings.deleteMany({ where: { user: { email: "test@example.com" } } });
+```
+
+The full cleanup block becomes:
+
+```typescript
+await prisma.budget.deleteMany({ where: { user: { email: "test@example.com" } } });
+await prisma.loanPayment.deleteMany({ where: { user: { email: "test@example.com" } } });
+await prisma.loan.deleteMany({ where: { user: { email: "test@example.com" } } });
+await prisma.transaction.deleteMany({ where: { user: { email: "test@example.com" } } });
+await prisma.transactionCategory.deleteMany({ where: { user: { email: "test@example.com" } } });
+await prisma.account.deleteMany({ where: { user: { email: "test@example.com" } } });
+await prisma.exchangeRate.deleteMany({ where: { user: { email: "test@example.com" } } });
+await prisma.asset.deleteMany({ where: { user: { email: "test@example.com" } } });
+await prisma.userSettings.deleteMany({ where: { user: { email: "test@example.com" } } });
+await prisma.user.deleteMany({ where: { email: "test@example.com" } });
+```
+
+- [ ] **Step 2: Re-run seed to verify**
+
+```bash
+pnpm db:seed
+```
+
+Expected: `Seed complete.` with no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add prisma/seed.ts
+git commit -m "fix: clear userSettings in seed cleanup"
+```

--- a/docs/superpowers/specs/2026-05-11-assets-networth-design.md
+++ b/docs/superpowers/specs/2026-05-11-assets-networth-design.md
@@ -1,0 +1,144 @@
+# Assets & Net Worth — Design Spec
+
+**Date:** 2026-05-11
+
+## Overview
+
+Add asset tracking (real estate, stocks, bonds, gold) and a net worth page that aggregates all accounts, assets, and loan liabilities into a single view.
+
+---
+
+## Data Model
+
+### New Prisma enum and model
+
+```prisma
+enum AssetType {
+  real_estate
+  stock
+  bond
+  gold
+}
+
+model Asset {
+  id           String    @id @default(cuid())
+  name         String
+  type         AssetType
+  currency     Currency  @default(USD)
+  currentValue Float
+  quantity     Float?    // shares, oz, units — null for real estate
+  ticker       String?   // stocks only, used for live price fetch
+  metadata     Json      @default("{}")
+  lastPricedAt DateTime?
+  userId       String
+  user         User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
+
+  @@index([userId, type])
+}
+```
+
+`User` model gets a new `assets Asset[]` relation.
+
+### `metadata` shape by asset type
+
+| Type | Fields |
+|------|--------|
+| `real_estate` | `{ address: string, purchasePrice: number, purchaseDate: string }` |
+| `stock` | `{ exchange: string }` — ticker is a top-level column |
+| `bond` | `{ issuer: string, interestRate: number, maturityDate: string }` |
+| `gold` | `{ form: string }` — e.g. "physical", "ETF" |
+
+### Price sources (free, no API key required)
+
+- **Stocks:** Yahoo Finance unofficial API — `https://query1.finance.yahoo.com/v8/finance/chart/{ticker}`
+- **Gold:** Open exchange rates or metals-api.com free tier for XAU/USD spot price
+
+`currentValue` stores the final dollar value (price × quantity for stocks/gold). `lastPricedAt` records when it was last refreshed.
+
+---
+
+## Pages
+
+### `/assets` page
+
+CRUD page for managing assets. Listed per-user, grouped or flat list. Each row shows:
+- Name, type badge, current value, currency, last priced time
+- Edit / delete actions
+- "Refresh price" button for stocks and gold (triggers live fetch)
+
+Asset form fields vary by type:
+- All types: name, currency, current value (manual override)
+- Stock: ticker, quantity, exchange
+- Gold: quantity, form (physical/ETF)
+- Bond: issuer, interest rate, maturity date
+- Real estate: address, purchase price, purchase date
+
+### `/networth` page
+
+Read-only aggregate view. Added to bottom nav.
+
+**Summary card:**
+- Total net worth = Σ account balances + Σ asset values − Σ outstanding loan principal
+- All values converted to default currency (USD) using existing `ExchangeRate` model
+
+**Breakdown sections:**
+1. **Liquid** — account balances, link to `/settings/accounts`
+2. **Assets** — grouped by type with subtotals, link to `/assets`
+3. **Liabilities** — outstanding loan balances, link to `/loans`
+
+---
+
+## API Routes
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/assets` | List all assets for current user |
+| POST | `/api/assets` | Create asset |
+| GET | `/api/assets/[id]` | Get single asset |
+| PATCH | `/api/assets/[id]` | Update asset |
+| DELETE | `/api/assets/[id]` | Delete asset |
+| POST | `/api/assets/[id]/refresh-price` | Fetch live price, update `currentValue` and `lastPricedAt` |
+| GET | `/api/networth` | Aggregate accounts + assets − loans with currency conversion |
+
+### `/api/networth` response shape
+
+```ts
+{
+  totalNetWorth: number,        // in USD
+  liquid: {
+    total: number,
+    accounts: { id, name, balance, currency, balanceInUsd }[]
+  },
+  assets: {
+    total: number,
+    byType: {
+      real_estate: { total: number, items: Asset[] },
+      stock:       { total: number, items: Asset[] },
+      bond:        { total: number, items: Asset[] },
+      gold:        { total: number, items: Asset[] },
+    }
+  },
+  liabilities: {
+    total: number,
+    loans: { id, name, outstandingPrincipal: number, currency, valueInUsd: number }[]
+  }
+}
+```
+
+---
+
+## Error Handling
+
+- Live price fetch failure: return 502 with message; `currentValue` and `lastPricedAt` unchanged
+- Missing exchange rate for currency conversion: skip conversion and flag in response (do not silently zero-out)
+- Invalid ticker on stock creation: validated at create/update time via a test fetch
+
+---
+
+## Out of Scope
+
+- Push notifications for price changes
+- Historical asset value tracking (charts over time)
+- Automated scheduled price refresh (can be added later)

--- a/docs/superpowers/specs/2026-05-11-default-currency-design.md
+++ b/docs/superpowers/specs/2026-05-11-default-currency-design.md
@@ -1,0 +1,108 @@
+# Default Display Currency — Design Spec
+
+**Date:** 2026-05-11
+
+## Overview
+
+Allow users to set a preferred display currency. All monetary summaries (home dashboard total balance, net worth page) convert values to this currency instead of inferring it from the default account or hardcoding USD.
+
+---
+
+## Approach
+
+Server-side conversion. The `/api/networth` endpoint reads `UserSettings.defaultCurrency` and converts all values before responding. The home page reads the setting client-side (already fetches exchange rates) and uses it as the conversion target. No conversion logic is duplicated — each consumer reads `settings.defaultCurrency` and applies the existing exchange rate logic.
+
+---
+
+## Data Model
+
+Add `defaultCurrency` to `UserSettings`:
+
+```prisma
+model UserSettings {
+  ...existing fields...
+  defaultCurrency  Currency  @default(USD)
+}
+```
+
+Migration: `pnpm prisma migrate dev --name add-default-currency`.
+
+---
+
+## Settings API (`/api/settings`)
+
+Add `"defaultCurrency"` to the `allowed` array in `PUT /api/settings/route.ts`. Values are validated by Prisma against the `Currency` enum (USD, VND).
+
+Update `lib/api/settings.ts`:
+- Add `defaultCurrency: Currency` to the `UserSettings` interface
+- Add `defaultCurrency` to `UserSettingsPayload`
+
+---
+
+## Net Worth API (`/api/networth`)
+
+**Changes:**
+- Fetch `UserSettings` (via `upsert` to guarantee a row) alongside accounts/assets/loans/rates
+- Rename internal helper `convertToUsd` → `convertToCurrency(amount, fromCurrency, toCurrency, rates)`
+- Use `settings.defaultCurrency` as the conversion target throughout
+- Add `currency` to the response:
+
+```ts
+{
+  currency: "VND",        // the target currency used for all totals
+  totalNetWorth: number,
+  missingRates: string[],
+  liquid: { total: number, accounts: AccountItem[] },
+  assets: { total: number, byType: AssetsByType },
+  liabilities: { total: number, loans: LoanItem[] }
+}
+```
+
+**Missing rate detection:** if a currency can't be converted to the target, its value is returned unconverted and its pair (e.g. `"VND/USD"` when converting VND to a USD target) is added to `missingRates`.
+
+---
+
+## Net Worth Client Types (`lib/api/networth.ts`)
+
+Add `currency: Currency` to `NetWorthResponse`.
+
+---
+
+## Home Page (`app/page.tsx`)
+
+**Current logic:**
+```ts
+const currency = defaultAccount?.currency ?? accounts[0]?.currency ?? "USD"
+```
+
+**New logic:**
+```ts
+const { data: settings } = useQuery({ queryKey: ["settings"], queryFn: getSettings });
+const currency = (settings?.defaultCurrency ?? "USD") as Currency;
+```
+
+The exchange rate conversion loop that computes `totalBalance` already handles any source currency → target currency, so no changes needed there beyond swapping `currency`.
+
+---
+
+## Settings UI (`app/settings/page.tsx`)
+
+Add an inline "Display Currency" control at the top of the settings page (above the menu list). It shows the current value and a dropdown to change it. On change, calls `PUT /api/settings` and invalidates `["settings"]` and `["networth"]` queries.
+
+```
+┌─────────────────────────────────┐
+│ Display Currency                │
+│ [USD ▾]                         │
+└─────────────────────────────────┘
+[settings menu items below]
+```
+
+This is a single inline component on the settings page — no new route needed.
+
+---
+
+## Out of Scope
+
+- Per-account currency override
+- Currencies beyond USD and VND
+- Automatic exchange rate refresh

--- a/lib/api/assets.ts
+++ b/lib/api/assets.ts
@@ -1,0 +1,58 @@
+import api from "@/lib/axios";
+import { Currency } from "./accounts";
+
+export type AssetType = "real_estate" | "stock" | "bond" | "gold";
+
+export interface Asset {
+  id: string;
+  name: string;
+  type: AssetType;
+  currency: Currency;
+  currentValue: number;
+  quantity: number | null;
+  ticker: string | null;
+  metadata: Record<string, unknown>;
+  lastPricedAt: string | null;
+  userId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AssetPayload {
+  name: string;
+  type: AssetType;
+  currency?: Currency;
+  currentValue: number;
+  quantity?: number | null;
+  ticker?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export async function getAssets(): Promise<Asset[]> {
+  const { data } = await api.get<Asset[]>("/assets");
+  return data;
+}
+
+export async function getAsset(id: string): Promise<Asset> {
+  const { data } = await api.get<Asset>(`/assets/${id}`);
+  return data;
+}
+
+export async function createAsset(payload: AssetPayload): Promise<Asset> {
+  const { data } = await api.post<Asset>("/assets", payload);
+  return data;
+}
+
+export async function updateAsset(id: string, payload: AssetPayload): Promise<Asset> {
+  const { data } = await api.patch<Asset>(`/assets/${id}`, payload);
+  return data;
+}
+
+export async function deleteAsset(id: string): Promise<void> {
+  await api.delete(`/assets/${id}`);
+}
+
+export async function refreshAssetPrice(id: string): Promise<Asset> {
+  const { data } = await api.post<Asset>(`/assets/${id}/refresh-price`);
+  return data;
+}

--- a/lib/api/networth.ts
+++ b/lib/api/networth.ts
@@ -7,7 +7,7 @@ export interface AccountItem {
   name: string;
   balance: number;
   currency: Currency;
-  valueInUsd: number;
+  valueInTarget: number;
 }
 
 export interface AssetItem {
@@ -19,7 +19,7 @@ export interface AssetItem {
   quantity: number | null;
   ticker: string | null;
   lastPricedAt: string | null;
-  valueInUsd: number;
+  valueInTarget: number;
 }
 
 export interface LoanItem {
@@ -28,7 +28,7 @@ export interface LoanItem {
   direction: "borrowed" | "lent";
   outstandingPrincipal: number;
   currency: Currency;
-  valueInUsd: number;
+  valueInTarget: number;
 }
 
 export interface AssetsByType {
@@ -39,6 +39,7 @@ export interface AssetsByType {
 }
 
 export interface NetWorthResponse {
+  currency: Currency;
   totalNetWorth: number;
   missingRates: string[];
   liquid: { total: number; accounts: AccountItem[] };

--- a/lib/api/networth.ts
+++ b/lib/api/networth.ts
@@ -1,0 +1,52 @@
+import api from "@/lib/axios";
+import { Currency } from "./accounts";
+import { AssetType } from "./assets";
+
+export interface AccountItem {
+  id: string;
+  name: string;
+  balance: number;
+  currency: Currency;
+  valueInUsd: number;
+}
+
+export interface AssetItem {
+  id: string;
+  name: string;
+  type: AssetType;
+  currency: Currency;
+  currentValue: number;
+  quantity: number | null;
+  ticker: string | null;
+  lastPricedAt: string | null;
+  valueInUsd: number;
+}
+
+export interface LoanItem {
+  id: string;
+  name: string;
+  direction: "borrowed" | "lent";
+  outstandingPrincipal: number;
+  currency: Currency;
+  valueInUsd: number;
+}
+
+export interface AssetsByType {
+  real_estate: { total: number; items: AssetItem[] };
+  stock: { total: number; items: AssetItem[] };
+  bond: { total: number; items: AssetItem[] };
+  gold: { total: number; items: AssetItem[] };
+}
+
+export interface NetWorthResponse {
+  totalNetWorth: number;
+  missingRates: string[];
+  liquid: { total: number; accounts: AccountItem[] };
+  assets: { total: number; byType: AssetsByType };
+  liabilities: { total: number; loans: LoanItem[] };
+}
+
+export async function getNetWorth(): Promise<NetWorthResponse> {
+  const { data } = await api.get<NetWorthResponse>("/networth");
+  return data;
+}

--- a/lib/api/settings.ts
+++ b/lib/api/settings.ts
@@ -1,8 +1,10 @@
 import api from "@/lib/axios";
+import { Currency } from "./accounts";
 
 export interface UserSettings {
   id: string;
   userId: string;
+  defaultCurrency: Currency;
   loanBorrowedInitialCategoryId: string | null;
   loanBorrowedPrincipalCategoryId: string | null;
   loanBorrowedInterestCategoryId: string | null;
@@ -17,6 +19,7 @@ export interface UserSettings {
 
 export type UserSettingsPayload = Partial<Pick<
   UserSettings,
+  | "defaultCurrency"
   | "loanBorrowedInitialCategoryId"
   | "loanBorrowedPrincipalCategoryId"
   | "loanBorrowedInterestCategoryId"

--- a/prisma/migrations/20260514005107_add_assets/migration.sql
+++ b/prisma/migrations/20260514005107_add_assets/migration.sql
@@ -1,0 +1,26 @@
+-- CreateEnum
+CREATE TYPE "AssetType" AS ENUM ('real_estate', 'stock', 'bond', 'gold');
+
+-- CreateTable
+CREATE TABLE "Asset" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "type" "AssetType" NOT NULL,
+    "currency" "Currency" NOT NULL DEFAULT 'USD',
+    "currentValue" DOUBLE PRECISION NOT NULL,
+    "quantity" DOUBLE PRECISION,
+    "ticker" TEXT,
+    "metadata" JSONB NOT NULL DEFAULT '{}',
+    "lastPricedAt" TIMESTAMP(3),
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Asset_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Asset_userId_type_idx" ON "Asset"("userId", "type");
+
+-- AddForeignKey
+ALTER TABLE "Asset" ADD CONSTRAINT "Asset_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260514011818_add_default_currency/migration.sql
+++ b/prisma/migrations/20260514011818_add_default_currency/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "UserSettings" ADD COLUMN     "defaultCurrency" "Currency" NOT NULL DEFAULT 'USD';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,6 +28,7 @@ model UserSettings {
   id                              String   @id @default(cuid())
   userId                          String   @unique
   user                            User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  defaultCurrency                 Currency @default(USD)
   loanBorrowedInitialCategoryId   String?
   loanBorrowedPrincipalCategoryId String?
   loanBorrowedInterestCategoryId  String?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,7 @@ model User {
   loans                Loan[]
   loanPayments         LoanPayment[]
   settings             UserSettings?
+  assets               Asset[]
 }
 
 model UserSettings {
@@ -205,4 +206,29 @@ model ExchangeRate {
   updatedAt    DateTime @updatedAt
 
   @@unique([userId, fromCurrency, toCurrency])
+}
+
+enum AssetType {
+  real_estate
+  stock
+  bond
+  gold
+}
+
+model Asset {
+  id           String    @id @default(cuid())
+  name         String
+  type         AssetType
+  currency     Currency  @default(USD)
+  currentValue Float
+  quantity     Float?
+  ticker       String?
+  metadata     Json      @default("{}")
+  lastPricedAt DateTime?
+  userId       String
+  user         User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
+
+  @@index([userId, type])
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -26,6 +26,10 @@ async function main() {
     data: { email: "test@example.com", password },
   });
 
+  await prisma.userSettings.create({
+    data: { userId: user.id, defaultCurrency: "VND" },
+  });
+
   const [checking, savings] = await Promise.all([
     prisma.account.create({
       data: { name: "Tài khoản thanh toán", balance: 10000000, currency: "VND", isDefault: true, userId: user.id },

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -17,6 +17,8 @@ async function main() {
   await prisma.transactionCategory.deleteMany({ where: { user: { email: "test@example.com" } } });
   await prisma.account.deleteMany({ where: { user: { email: "test@example.com" } } });
   await prisma.exchangeRate.deleteMany({ where: { user: { email: "test@example.com" } } });
+  await prisma.asset.deleteMany({ where: { user: { email: "test@example.com" } } });
+  await prisma.userSettings.deleteMany({ where: { user: { email: "test@example.com" } } });
   await prisma.user.deleteMany({ where: { email: "test@example.com" } });
 
   const password = await bcrypt.hash("password123", 10);
@@ -345,6 +347,57 @@ async function main() {
       initialTransactionId: lentLoanInitialTx.id,
       userId: user.id,
     },
+  });
+
+  // Seed assets
+  await prisma.asset.createMany({
+    data: [
+      {
+        name: "Căn hộ Vinhomes",
+        type: "real_estate",
+        currency: "VND",
+        currentValue: 3_500_000_000,
+        metadata: { address: "Vinhomes Grand Park, Quận 9, TP.HCM", purchasePrice: 2_800_000_000, purchaseDate: "2022-06-15" },
+        userId: user.id,
+      },
+      {
+        name: "Apple (AAPL)",
+        type: "stock",
+        currency: "USD",
+        currentValue: 34_650,
+        quantity: 150,
+        ticker: "AAPL",
+        metadata: { exchange: "NASDAQ" },
+        userId: user.id,
+      },
+      {
+        name: "VN30 ETF",
+        type: "stock",
+        currency: "VND",
+        currentValue: 45_000_000,
+        quantity: 3000,
+        ticker: "E1VFVN30",
+        metadata: { exchange: "HOSE" },
+        userId: user.id,
+      },
+      {
+        name: "Trái phiếu Chính phủ",
+        type: "bond",
+        currency: "VND",
+        currentValue: 200_000_000,
+        metadata: { issuer: "Bộ Tài chính Việt Nam", interestRate: 5.8, maturityDate: "2028-03-01" },
+        userId: user.id,
+      },
+      {
+        name: "Vàng SJC",
+        type: "gold",
+        currency: "VND",
+        currentValue: 60_000_000,
+        quantity: 1,
+        metadata: { form: "physical" },
+        userId: user.id,
+      },
+    ],
   });
 
   console.log("Seed complete.");


### PR DESCRIPTION
## Summary

- **Asset management** — CRUD for real estate, stocks, bonds, and gold; live price refresh via Yahoo Finance (stocks) and open.er-api.com (gold)
- **Net worth page** — read-only aggregate view of liquid accounts + assets − loan liabilities, grouped by type with missing exchange rate warnings
- **Display currency setting** — users set a preferred currency (USD/VND) in Settings; all summaries on the home and net worth pages convert server-side to that currency
- **Nav cleanup** — reduced bottom nav from 7 to 4 items (Home, Transactions, Net Worth, Settings); Budgets, Assets, and Loans moved to Settings page

## Test plan

- [ ] Add assets of each type (real estate, stock, bond, gold) and verify they appear grouped correctly on `/assets`
- [ ] Refresh price on a stock (e.g. AAPL) and gold asset — verify `currentValue` and `lastPricedAt` update
- [ ] Visit `/networth` — verify liquid, assets, and liabilities sections show correct totals in display currency
- [ ] Switch display currency between USD and VND in Settings — verify home total balance and net worth update accordingly
- [ ] Re-seed dev DB (`pnpm run db:seed`) and confirm default currency is VND
- [ ] Verify bottom nav shows only 4 items; Budgets/Assets/Loans accessible from Settings