### PR TITLE
feat: add transaction location via OpenTimeline integration

### DIFF
--- a/app/api/integrations/opentimeline/places/route.ts
+++ b/app/api/integrations/opentimeline/places/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/app/lib/db";
+import { getSession } from "@/app/lib/auth";
+
+export async function GET(req: NextRequest) {
+  const session = await getSession(req);
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const q = req.nextUrl.searchParams.get("q")?.trim();
+  if (!q) return NextResponse.json({ places: [] });
+
+  const settings = await prisma.userSettings.findUnique({ where: { userId: session.userId } });
+  if (!settings?.openTimelineUrl) {
+    return NextResponse.json({ places: [] });
+  }
+
+  try {
+    const url = new URL("/api/places", settings.openTimelineUrl);
+    url.searchParams.set("q", q);
+    url.searchParams.set("limit", "10");
+
+    const res = await fetch(url.toString(), { signal: AbortSignal.timeout(5000) });
+    if (!res.ok) return NextResponse.json({ places: [] });
+
+    const data: { places?: { id: number; name: string }[] } = await res.json();
+    const places = (data.places ?? []).map((p) => ({ id: String(p.id), name: p.name }));
+    return NextResponse.json({ places });
+  } catch {
+    return NextResponse.json({ places: [] });
+  }
+}

--- a/app/api/integrations/opentimeline/visits/route.ts
+++ b/app/api/integrations/opentimeline/visits/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/app/lib/db";
+import { getSession } from "@/app/lib/auth";
+
+export async function GET(req: NextRequest) {
+  const session = await getSession(req);
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const at = req.nextUrl.searchParams.get("at");
+  if (!at) return NextResponse.json({ error: "at parameter required" }, { status: 400 });
+
+  const atDate = new Date(at);
+  if (isNaN(atDate.getTime())) {
+    return NextResponse.json({ error: "Invalid at parameter" }, { status: 400 });
+  }
+
+  const settings = await prisma.userSettings.findUnique({ where: { userId: session.userId } });
+  if (!settings?.openTimelineUrl) {
+    return NextResponse.json(null);
+  }
+
+  // Query the full UTC day so partial-day visits overlapping the transaction are included
+  const dayStart = new Date(atDate);
+  dayStart.setUTCHours(0, 0, 0, 0);
+  const dayEnd = new Date(atDate);
+  dayEnd.setUTCHours(23, 59, 59, 999);
+
+  try {
+    const url = new URL("/api/visits", settings.openTimelineUrl);
+    url.searchParams.set("start", dayStart.toISOString());
+    url.searchParams.set("end", dayEnd.toISOString());
+    url.searchParams.set("status", "confirmed");
+
+    const res = await fetch(url.toString(), { signal: AbortSignal.timeout(5000) });
+    if (!res.ok) return NextResponse.json(null);
+
+    const visits: { placeId?: number; place?: { id: number; name: string } }[] = await res.json();
+    if (!Array.isArray(visits) || visits.length === 0) return NextResponse.json(null);
+
+    const first = visits[0];
+    const placeId = first.place?.id ?? first.placeId;
+    const placeName = first.place?.name;
+    if (placeId == null || !placeName) return NextResponse.json(null);
+
+    return NextResponse.json({ placeId: String(placeId), placeName });
+  } catch {
+    return NextResponse.json(null);
+  }
+}

--- a/app/api/integrations/opentimeline/visits/route.ts
+++ b/app/api/integrations/opentimeline/visits/route.ts
@@ -16,10 +16,10 @@ export async function GET(req: NextRequest) {
 
   const settings = await prisma.userSettings.findUnique({ where: { userId: session.userId } });
   if (!settings?.openTimelineUrl) {
-    return NextResponse.json(null);
+    return NextResponse.json({ places: [] });
   }
 
-  // Query the full UTC day so partial-day visits overlapping the transaction are included
+  // Query the full UTC day so all visits overlapping the transaction date are included
   const dayStart = new Date(atDate);
   dayStart.setUTCHours(0, 0, 0, 0);
   const dayEnd = new Date(atDate);
@@ -32,18 +32,26 @@ export async function GET(req: NextRequest) {
     url.searchParams.set("status", "confirmed");
 
     const res = await fetch(url.toString(), { signal: AbortSignal.timeout(5000) });
-    if (!res.ok) return NextResponse.json(null);
+    if (!res.ok) return NextResponse.json({ places: [] });
 
     const visits: { placeId?: number; place?: { id: number; name: string } }[] = await res.json();
-    if (!Array.isArray(visits) || visits.length === 0) return NextResponse.json(null);
+    if (!Array.isArray(visits)) return NextResponse.json({ places: [] });
 
-    const first = visits[0];
-    const placeId = first.place?.id ?? first.placeId;
-    const placeName = first.place?.name;
-    if (placeId == null || !placeName) return NextResponse.json(null);
+    // Collect every visited place for the day, de-duplicated, preserving arrival order
+    const seen = new Set<string>();
+    const places: { id: string; name: string }[] = [];
+    for (const v of visits) {
+      const id = v.place?.id ?? v.placeId;
+      const name = v.place?.name;
+      if (id == null || !name) continue;
+      const key = String(id);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      places.push({ id: key, name });
+    }
 
-    return NextResponse.json({ placeId: String(placeId), placeName });
+    return NextResponse.json({ places });
   } catch {
-    return NextResponse.json(null);
+    return NextResponse.json({ places: [] });
   }
 }

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -32,6 +32,7 @@ export async function PUT(req: NextRequest) {
     "loanLentPrincipalCategoryId",
     "loanLentInterestCategoryId",
     "loanLentPrepayFeeCategoryId",
+    "openTimelineUrl",
   ] as const;
 
   const data: Record<string, string | null> = {};

--- a/app/api/transactions/[id]/route.ts
+++ b/app/api/transactions/[id]/route.ts
@@ -28,7 +28,7 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
     );
   }
 
-  const { amount, date, description, details, accountId, categoryId } = await req.json();
+  const { amount, date, description, details, accountId, categoryId, locationPlaceId, locationPlaceName } = await req.json();
 
   if (!amount || amount <= 0) {
     return NextResponse.json({ error: "Amount must be positive" }, { status: 400 });
@@ -58,6 +58,8 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
       date: parseDateParam(date, session.timezone),
       description: description?.trim() || null,
       details: details?.trim() || null,
+      locationPlaceId: locationPlaceId?.trim() || null,
+      locationPlaceName: locationPlaceName?.trim() || null,
       accountId,
       categoryId,
     },

--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -19,6 +19,7 @@ export async function GET(req: NextRequest) {
     const rows = await prisma.$queryRaw<unknown[]>`
       SELECT
         t.id, t.amount, t.date, t.description, t.details,
+        t."locationPlaceId", t."locationPlaceName",
         t."accountId", t."categoryId", t."userId", t."createdAt", t."updatedAt",
         json_build_object('id', a.id, 'name', a.name, 'currency', a.currency::text) AS account,
         json_build_object('id', c.id, 'name', c.name, 'type', c.type::text, 'icon', c.icon) AS category,
@@ -81,7 +82,7 @@ export async function POST(req: NextRequest) {
   const session = await getSession(req);
   if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const { amount, date, description, details, accountId, categoryId } = await req.json();
+  const { amount, date, description, details, accountId, categoryId, locationPlaceId, locationPlaceName } = await req.json();
 
   if (!amount || amount <= 0) {
     return NextResponse.json({ error: "Amount must be positive" }, { status: 400 });
@@ -110,6 +111,8 @@ export async function POST(req: NextRequest) {
       date: parseDateParam(date, session.timezone),
       description: description?.trim() || null,
       details: details?.trim() || null,
+      locationPlaceId: locationPlaceId?.trim() || null,
+      locationPlaceName: locationPlaceName?.trim() || null,
       accountId,
       categoryId,
       userId: session.userId,

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { ChevronRight, CreditCard, Tag, User, DollarSign, Upload, Landmark, PiggyBank, Building2, HandCoins } from "lucide-react";
+import { ChevronRight, CreditCard, Tag, User, DollarSign, Upload, Landmark, PiggyBank, Building2, HandCoins, Link2 } from "lucide-react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { ImportDialog } from "@/components/transactions/import-dialog";
 import { getSettings, updateSettings } from "@/lib/api/settings";
@@ -68,6 +68,26 @@ export default function SettingsPage() {
             <option key={tz} value={tz}>{tz}</option>
           ))}
         </select>
+      </div>
+
+      <div className="rounded-lg border px-4 py-3">
+        <p className="text-sm font-medium mb-0.5 flex items-center gap-2">
+          <Link2 className="size-4" />
+          OpenTimeline
+        </p>
+        <p className="text-xs text-muted-foreground mb-3">
+          Connect your OpenTimeline instance to auto-suggest locations on transactions
+        </p>
+        <input
+          type="url"
+          placeholder="http://localhost:3000"
+          defaultValue={settings?.openTimelineUrl ?? ""}
+          className="w-full rounded-md border bg-background px-3 py-2 text-[16px] md:text-sm"
+          onBlur={(e) => {
+            const val = e.target.value.trim();
+            updateMutation.mutate({ openTimelineUrl: val || null });
+          }}
+        />
       </div>
 
       <div className="divide-y rounded-lg border overflow-hidden">

--- a/app/transactions/page.tsx
+++ b/app/transactions/page.tsx
@@ -82,8 +82,11 @@ export default function TransactionsPage() {
       amount: number;
       date: string;
       description?: string;
+      details?: string;
       accountId: string;
       categoryId: string;
+      locationPlaceId?: string | null;
+      locationPlaceName?: string | null;
     }) => updateTransaction(id, payload),
     onSuccess: invalidate,
   });
@@ -107,8 +110,11 @@ export default function TransactionsPage() {
     amount: number;
     date: string;
     description?: string;
+    details?: string;
     accountId: string;
     categoryId: string;
+    locationPlaceId?: string | null;
+    locationPlaceName?: string | null;
   }) {
     if (editingTransaction) {
       await updateMutation.mutateAsync({ id: editingTransaction.id, ...payload });

--- a/components/transactions/location-picker.tsx
+++ b/components/transactions/location-picker.tsx
@@ -5,7 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import { MapPin, X, Search } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { getVisitSuggestion, searchPlaces, OpenTimelinePlace } from "@/lib/api/opentimeline";
+import { getVisitSuggestions, searchPlaces, OpenTimelinePlace } from "@/lib/api/opentimeline";
 import { getSettings } from "@/lib/api/settings";
 
 interface LocationPickerProps {
@@ -17,26 +17,24 @@ interface LocationPickerProps {
 export function LocationPicker({ date, value, onChange }: LocationPickerProps) {
   // All hooks must be called unconditionally before any early return
   const { data: settings } = useQuery({ queryKey: ["settings"], queryFn: getSettings });
-  const [dismissed, setDismissed] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [showDropdown, setShowDropdown] = useState(false);
   const prevDateRef = useRef(date);
 
   const configured = !!settings?.openTimelineUrl;
 
-  // Reset dismissed state when date changes
+  // Clear the manual search when the date changes
   useEffect(() => {
     if (prevDateRef.current !== date) {
       prevDateRef.current = date;
-      setDismissed(false);
       setSearchQuery("");
     }
   }, [date]);
 
-  const { data: suggestion, isLoading: isSuggesting } = useQuery({
+  const { data: suggestions = [], isLoading: isSuggesting } = useQuery({
     queryKey: ["opentimeline-visit", date],
-    queryFn: () => getVisitSuggestion(date),
-    enabled: configured && !!date && !value && !dismissed,
+    queryFn: () => getVisitSuggestions(date),
+    enabled: configured && !!date && !value,
     retry: false,
     staleTime: 60_000,
   });
@@ -62,7 +60,7 @@ export function LocationPicker({ date, value, onChange }: LocationPickerProps) {
           <span className="flex-1 truncate">{value.name}</span>
           <button
             type="button"
-            onClick={() => { onChange(null); setDismissed(false); }}
+            onClick={() => onChange(null)}
             className="text-muted-foreground hover:text-foreground"
             aria-label="Clear location"
           >
@@ -73,51 +71,32 @@ export function LocationPicker({ date, value, onChange }: LocationPickerProps) {
     );
   }
 
-  // Auto-suggestion available
-  if (!dismissed && suggestion) {
-    return (
-      <div className="space-y-2">
-        <Label>Location (optional)</Label>
-        <div className="flex items-center gap-2 rounded-md border border-primary/40 bg-primary/5 px-3 py-2 text-sm">
-          <MapPin className="size-4 text-primary shrink-0" />
-          <span className="flex-1 truncate text-foreground">{suggestion.name}</span>
-          <button
-            type="button"
-            onClick={() => onChange(suggestion)}
-            className="text-xs font-medium text-primary hover:text-primary/80 shrink-0"
-          >
-            Accept
-          </button>
-          <button
-            type="button"
-            onClick={() => setDismissed(true)}
-            className="text-muted-foreground hover:text-foreground"
-            aria-label="Dismiss suggestion"
-          >
-            <X className="size-4" />
-          </button>
-        </div>
-      </div>
-    );
-  }
-
-  // Suggestion loading
-  if (!dismissed && isSuggesting) {
-    return (
-      <div className="space-y-2">
-        <Label>Location (optional)</Label>
-        <div className="flex items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm text-muted-foreground animate-pulse">
-          <MapPin className="size-4 shrink-0" />
-          <span>Looking up location…</span>
-        </div>
-      </div>
-    );
-  }
-
-  // Manual search
+  // No value yet — show the day's visited places as pills, plus manual search
   return (
     <div className="space-y-2">
       <Label>Location (optional)</Label>
+
+      {isSuggesting ? (
+        <div className="flex items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm text-muted-foreground animate-pulse">
+          <MapPin className="size-4 shrink-0" />
+          <span>Looking up places…</span>
+        </div>
+      ) : suggestions.length > 0 ? (
+        <div className="flex flex-wrap gap-2">
+          {suggestions.map((place) => (
+            <button
+              key={place.id}
+              type="button"
+              onClick={() => onChange(place)}
+              className="flex items-center gap-1.5 rounded-full border border-primary/40 bg-primary/5 px-3 py-1.5 text-sm text-foreground hover:bg-primary/10 transition-colors max-w-full"
+            >
+              <MapPin className="size-3.5 text-primary shrink-0" />
+              <span className="truncate">{place.name}</span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+
       <div className="relative">
         <div className="flex items-center rounded-md border border-input bg-background px-3 gap-2">
           <Search className="size-4 text-muted-foreground shrink-0" />

--- a/components/transactions/location-picker.tsx
+++ b/components/transactions/location-picker.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { MapPin, X, Search } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { getVisitSuggestion, searchPlaces, OpenTimelinePlace } from "@/lib/api/opentimeline";
+import { getSettings } from "@/lib/api/settings";
+
+interface LocationPickerProps {
+  date: string;
+  value: OpenTimelinePlace | null;
+  onChange: (value: OpenTimelinePlace | null) => void;
+}
+
+export function LocationPicker({ date, value, onChange }: LocationPickerProps) {
+  // All hooks must be called unconditionally before any early return
+  const { data: settings } = useQuery({ queryKey: ["settings"], queryFn: getSettings });
+  const [dismissed, setDismissed] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [showDropdown, setShowDropdown] = useState(false);
+  const prevDateRef = useRef(date);
+
+  const configured = !!settings?.openTimelineUrl;
+
+  // Reset dismissed state when date changes
+  useEffect(() => {
+    if (prevDateRef.current !== date) {
+      prevDateRef.current = date;
+      setDismissed(false);
+      setSearchQuery("");
+    }
+  }, [date]);
+
+  const { data: suggestion, isLoading: isSuggesting } = useQuery({
+    queryKey: ["opentimeline-visit", date],
+    queryFn: () => getVisitSuggestion(date),
+    enabled: configured && !!date && !value && !dismissed,
+    retry: false,
+    staleTime: 60_000,
+  });
+
+  const { data: searchResults = [] } = useQuery({
+    queryKey: ["opentimeline-places", searchQuery],
+    queryFn: () => searchPlaces(searchQuery),
+    enabled: configured && searchQuery.length >= 2,
+    retry: false,
+    staleTime: 30_000,
+  });
+
+  // Hidden entirely when OpenTimeline is not configured
+  if (!configured) return null;
+
+  // Confirmed value — show with clear button
+  if (value) {
+    return (
+      <div className="space-y-2">
+        <Label>Location (optional)</Label>
+        <div className="flex items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm">
+          <MapPin className="size-4 text-muted-foreground shrink-0" />
+          <span className="flex-1 truncate">{value.name}</span>
+          <button
+            type="button"
+            onClick={() => { onChange(null); setDismissed(false); }}
+            className="text-muted-foreground hover:text-foreground"
+            aria-label="Clear location"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Auto-suggestion available
+  if (!dismissed && suggestion) {
+    return (
+      <div className="space-y-2">
+        <Label>Location (optional)</Label>
+        <div className="flex items-center gap-2 rounded-md border border-primary/40 bg-primary/5 px-3 py-2 text-sm">
+          <MapPin className="size-4 text-primary shrink-0" />
+          <span className="flex-1 truncate text-foreground">{suggestion.name}</span>
+          <button
+            type="button"
+            onClick={() => onChange(suggestion)}
+            className="text-xs font-medium text-primary hover:text-primary/80 shrink-0"
+          >
+            Accept
+          </button>
+          <button
+            type="button"
+            onClick={() => setDismissed(true)}
+            className="text-muted-foreground hover:text-foreground"
+            aria-label="Dismiss suggestion"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Suggestion loading
+  if (!dismissed && isSuggesting) {
+    return (
+      <div className="space-y-2">
+        <Label>Location (optional)</Label>
+        <div className="flex items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm text-muted-foreground animate-pulse">
+          <MapPin className="size-4 shrink-0" />
+          <span>Looking up location…</span>
+        </div>
+      </div>
+    );
+  }
+
+  // Manual search
+  return (
+    <div className="space-y-2">
+      <Label>Location (optional)</Label>
+      <div className="relative">
+        <div className="flex items-center rounded-md border border-input bg-background px-3 gap-2">
+          <Search className="size-4 text-muted-foreground shrink-0" />
+          <Input
+            type="text"
+            placeholder="Search location…"
+            value={searchQuery}
+            onChange={(e) => { setSearchQuery(e.target.value); setShowDropdown(true); }}
+            onFocus={() => setShowDropdown(true)}
+            onBlur={() => setTimeout(() => setShowDropdown(false), 150)}
+            className="border-0 shadow-none px-0 text-[16px] md:text-sm focus-visible:ring-0"
+          />
+        </div>
+        {showDropdown && searchResults.length > 0 && (
+          <ul className="absolute z-50 w-full mt-1 rounded-md border bg-popover shadow-md overflow-hidden">
+            {searchResults.map((place) => (
+              <li key={place.id}>
+                <button
+                  type="button"
+                  onMouseDown={() => { onChange(place); setSearchQuery(""); setShowDropdown(false); }}
+                  className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-accent text-left"
+                >
+                  <MapPin className="size-4 text-muted-foreground shrink-0" />
+                  {place.name}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/transactions/transaction-detail.tsx
+++ b/components/transactions/transaction-detail.tsx
@@ -127,6 +127,7 @@ export function TransactionDetail({
               )}
               <Row label="Date" value={formattedDate} />
               <Row label="Account" value={tx.account.name} />
+              {tx.locationPlaceName && <Row label="Location" value={tx.locationPlaceName} />}
               {tx.details && (
                 <div className="flex flex-col gap-1">
                   <span className="text-muted-foreground">Details</span>

--- a/components/transactions/transaction-form.tsx
+++ b/components/transactions/transaction-form.tsx
@@ -182,17 +182,26 @@ export function TransactionForm({
       : null
   );
 
-  // Reset form state when a different transaction is shown, adjusting state
-  // during render (React's recommended alternative to a syncing effect).
-  const [prevTransactionId, setPrevTransactionId] = useState(transaction?.id);
-  if (transaction?.id !== prevTransactionId) {
-    setPrevTransactionId(transaction?.id);
-    setSelectedCategoryId(transaction?.categoryId ?? "");
-    setLocation(
-      transaction?.locationPlaceId && transaction?.locationPlaceName
-        ? { id: transaction.locationPlaceId, name: transaction.locationPlaceName }
-        : null
-    );
+  // The dialog stays mounted across open/close, so reset all form state each
+  // time it opens. Bumping formInstance also remounts TransactionFields, which
+  // clears its local date state and the uncontrolled amount/description/details
+  // inputs. Adjusting state during render is React's recommended alternative to
+  // a syncing effect.
+  const [formInstance, setFormInstance] = useState(0);
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (open) {
+      setError("");
+      setConfirmDelete(false);
+      setSelectedCategoryId(transaction?.categoryId ?? "");
+      setLocation(
+        transaction?.locationPlaceId && transaction?.locationPlaceName
+          ? { id: transaction.locationPlaceId, name: transaction.locationPlaceName }
+          : null
+      );
+      setFormInstance((n) => n + 1);
+    }
   }
 
   const defaultAccount = accounts.find((a) => a.isDefault) ?? accounts[0];
@@ -252,7 +261,7 @@ export function TransactionForm({
         <form onSubmit={handleSubmit} className="flex-1 flex flex-col min-h-0">
           <div className="overflow-y-auto flex-1">
             <TransactionFields
-              key={transaction?.id ?? "new"}
+              key={`${transaction?.id ?? "new"}-${formInstance}`}
               transaction={transaction}
               accounts={accounts}
               categories={categories}

--- a/components/transactions/transaction-form.tsx
+++ b/components/transactions/transaction-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, FormEvent } from "react";
+import { useState, FormEvent } from "react";
 import { ChevronLeft, ChevronRight, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -13,10 +13,12 @@ import {
 } from "@/components/ui/dialog";
 import { AmountInput } from "@/components/transactions/amount-input";
 import { CategorySelector } from "@/components/transactions/category-selector";
+import { LocationPicker } from "@/components/transactions/location-picker";
 import { localDayToISO } from "@/lib/dates";
 import { Transaction } from "@/lib/api/transactions";
 import { Account } from "@/lib/api/accounts";
 import { TransactionCategory } from "@/lib/api/transaction-categories";
+import { OpenTimelinePlace } from "@/lib/api/opentimeline";
 
 interface TransactionFieldsProps {
   transaction?: Transaction | null;
@@ -27,6 +29,8 @@ interface TransactionFieldsProps {
   error: string;
   selectedCategoryId: string;
   onCategoryChange: (id: string) => void;
+  location: OpenTimelinePlace | null;
+  onLocationChange: (value: OpenTimelinePlace | null) => void;
 }
 
 function TransactionFields({
@@ -38,6 +42,8 @@ function TransactionFields({
   error,
   selectedCategoryId,
   onCategoryChange,
+  location,
+  onLocationChange,
 }: TransactionFieldsProps) {
   const [date, setDate] = useState(defaultDate);
 
@@ -129,6 +135,8 @@ function TransactionFields({
         />
       </div>
 
+      <LocationPicker date={date} value={location} onChange={onLocationChange} />
+
       {error && <p className="text-sm text-destructive">{error}</p>}
     </div>
   );
@@ -147,6 +155,8 @@ interface TransactionFormProps {
     details?: string;
     accountId: string;
     categoryId: string;
+    locationPlaceId?: string | null;
+    locationPlaceName?: string | null;
   }) => Promise<void>;
   onDelete?: (transaction: Transaction) => Promise<void>;
 }
@@ -166,10 +176,24 @@ export function TransactionForm({
   const [selectedCategoryId, setSelectedCategoryId] = useState(
     transaction?.categoryId ?? ""
   );
+  const [location, setLocation] = useState<OpenTimelinePlace | null>(
+    transaction?.locationPlaceId && transaction?.locationPlaceName
+      ? { id: transaction.locationPlaceId, name: transaction.locationPlaceName }
+      : null
+  );
 
-  useEffect(() => {
+  // Reset form state when a different transaction is shown, adjusting state
+  // during render (React's recommended alternative to a syncing effect).
+  const [prevTransactionId, setPrevTransactionId] = useState(transaction?.id);
+  if (transaction?.id !== prevTransactionId) {
+    setPrevTransactionId(transaction?.id);
     setSelectedCategoryId(transaction?.categoryId ?? "");
-  }, [transaction?.id, transaction?.categoryId]);
+    setLocation(
+      transaction?.locationPlaceId && transaction?.locationPlaceName
+        ? { id: transaction.locationPlaceId, name: transaction.locationPlaceName }
+        : null
+    );
+  }
 
   const defaultAccount = accounts.find((a) => a.isDefault) ?? accounts[0];
 
@@ -193,7 +217,16 @@ export function TransactionForm({
     }
 
     try {
-      await onSubmit({ amount, date: localDayToISO(date), description: description || undefined, details: details || undefined, accountId, categoryId });
+      await onSubmit({
+        amount,
+        date: localDayToISO(date),
+        description: description || undefined,
+        details: details || undefined,
+        accountId,
+        categoryId,
+        locationPlaceId: location?.id ?? null,
+        locationPlaceName: location?.name ?? null,
+      });
       onClose();
     } catch (err: unknown) {
       const message =
@@ -228,6 +261,8 @@ export function TransactionForm({
               error={error}
               selectedCategoryId={selectedCategoryId}
               onCategoryChange={setSelectedCategoryId}
+              location={location}
+              onLocationChange={setLocation}
             />
           </div>
           <div className="flex items-center justify-between pt-4 gap-2">

--- a/components/transactions/transaction-row.tsx
+++ b/components/transactions/transaction-row.tsx
@@ -4,7 +4,7 @@ import { Transaction } from "@/lib/api/transactions";
 import { CategoryType } from "@/lib/api/transaction-categories";
 import { formatCurrency } from "@/lib/utils";
 import { CategoryIcon } from "@/components/transaction-categories/category-icon";
-import { Landmark } from "lucide-react";
+import { Landmark, MapPin } from "lucide-react";
 
 const TYPE_COLORS: Record<CategoryType, string> = {
   income: "text-green-600 dark:text-green-400",
@@ -68,6 +68,15 @@ export function TransactionRow({ transaction, onEdit }: TransactionRowProps) {
             <p className="text-xs text-muted-foreground">{formattedDate}</p>
             <span className="text-xs text-muted-foreground">·</span>
             <p className="text-xs text-muted-foreground">{transaction.account.name}</p>
+            {transaction.locationPlaceName && (
+              <>
+                <span className="text-xs text-muted-foreground">·</span>
+                <span className="flex items-center gap-1 text-xs text-muted-foreground min-w-0">
+                  <MapPin size={11} className="shrink-0" />
+                  <span className="truncate">{transaction.locationPlaceName}</span>
+                </span>
+              </>
+            )}
             {loanPayment && (
               <>
                 <span className="text-xs text-muted-foreground">·</span>

--- a/docs/superpowers/plans/2026-06-29-transaction-location-opentimeline.md
+++ b/docs/superpowers/plans/2026-06-29-transaction-location-opentimeline.md
@@ -1,0 +1,1010 @@
+# Transaction Location via OpenTimeline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add optional location to transactions by integrating with the user's self-hosted OpenTimeline instance — auto-suggesting place on date and falling back to manual search.
+
+**Architecture:** A backend proxy layer in wealth-manager reads the OpenTimeline URL from `UserSettings` and forwards requests server-side (avoiding CORS). The transaction form auto-queries the proxy for a visit suggestion on the selected date; users can accept, clear, or manually search places. Location is stored as `locationPlaceId` + `locationPlaceName` on `Transaction`.
+
+**Tech Stack:** Next.js App Router API routes, Prisma (PostgreSQL), React, react-query (`useQuery`/`useMutation`), axios, shadcn UI components, TypeScript, vitest.
+
+## Global Constraints
+
+- Mobile-first; use `text-[16px] md:text-sm` on any new inputs
+- Use shadcn components (`Input`, `Button`, `Label`) from `@/components/ui/`
+- API calls use `api` (axios instance) from `@/lib/axios`; server routes use `@/app/lib/db` for prisma and `@/app/lib/auth` for `getSession`
+- No new dependencies — everything needed is already installed
+- Run `pnpm exec eslint <path>` after each task to catch lint errors
+
+---
+
+### Task 1: DB migration — add location to Transaction and openTimelineUrl to UserSettings
+
+**Files:**
+- Modify: `prisma/schema.prisma`
+
+**Interfaces:**
+- Produces: `Transaction.locationPlaceId: String?`, `Transaction.locationPlaceName: String?`, `UserSettings.openTimelineUrl: String?` — all later tasks depend on these columns existing
+
+- [ ] **Step 1: Edit prisma/schema.prisma — add openTimelineUrl to UserSettings**
+
+In `prisma/schema.prisma`, add the field after the last `loanLentPrepayFeeCategoryId` line (line ~40):
+
+```prisma
+  loanLentPrepayFeeCategoryId     String?
+  openTimelineUrl                 String?
+  createdAt                       DateTime @default(now())
+```
+
+- [ ] **Step 2: Edit prisma/schema.prisma — add location fields to Transaction**
+
+Find the `Transaction` model and add two fields before `createdAt`:
+
+```prisma
+  locationPlaceId    String?
+  locationPlaceName  String?
+  createdAt          DateTime            @default(now())
+```
+
+- [ ] **Step 3: Run migration**
+
+```bash
+pnpm exec prisma migrate dev --name add_location_to_transactions
+```
+
+Expected output: `Your database is now in sync with your schema.`
+
+- [ ] **Step 4: Regenerate Prisma client**
+
+```bash
+pnpm exec prisma generate
+```
+
+- [ ] **Step 5: Verify TypeScript compiles**
+
+```bash
+pnpm exec tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add prisma/schema.prisma prisma/migrations/
+git commit -m "feat: add location fields to Transaction and openTimelineUrl to UserSettings"
+```
+
+---
+
+### Task 2: Settings API — expose openTimelineUrl
+
+**Files:**
+- Modify: `app/api/settings/route.ts`
+- Modify: `lib/api/settings.ts`
+
+**Interfaces:**
+- Consumes: `UserSettings.openTimelineUrl` from Task 1
+- Produces: `UserSettings.openTimelineUrl: string | null` in the API response; `UserSettingsPayload` now accepts `openTimelineUrl`
+
+- [ ] **Step 1: Update `app/api/settings/route.ts` — add openTimelineUrl to allowed keys**
+
+Find the `allowed` array and add the new key:
+
+```typescript
+  const allowed = [
+    "defaultCurrency",
+    "timezone",
+    "loanBorrowedInitialCategoryId",
+    "loanBorrowedPrincipalCategoryId",
+    "loanBorrowedInterestCategoryId",
+    "loanBorrowedPrepayFeeCategoryId",
+    "loanLentInitialCategoryId",
+    "loanLentPrincipalCategoryId",
+    "loanLentInterestCategoryId",
+    "loanLentPrepayFeeCategoryId",
+    "openTimelineUrl",
+  ] as const;
+```
+
+- [ ] **Step 2: Update `lib/api/settings.ts` — add openTimelineUrl to interface and payload type**
+
+Add `openTimelineUrl: string | null;` to `UserSettings`:
+
+```typescript
+export interface UserSettings {
+  id: string;
+  userId: string;
+  defaultCurrency: Currency;
+  timezone: string;
+  loanBorrowedInitialCategoryId: string | null;
+  loanBorrowedPrincipalCategoryId: string | null;
+  loanBorrowedInterestCategoryId: string | null;
+  loanBorrowedPrepayFeeCategoryId: string | null;
+  loanLentInitialCategoryId: string | null;
+  loanLentPrincipalCategoryId: string | null;
+  loanLentInterestCategoryId: string | null;
+  loanLentPrepayFeeCategoryId: string | null;
+  openTimelineUrl: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+```
+
+Update `UserSettingsPayload` to include `openTimelineUrl`:
+
+```typescript
+export type UserSettingsPayload = Partial<Pick<
+  UserSettings,
+  | "defaultCurrency"
+  | "timezone"
+  | "loanBorrowedInitialCategoryId"
+  | "loanBorrowedPrincipalCategoryId"
+  | "loanBorrowedInterestCategoryId"
+  | "loanBorrowedPrepayFeeCategoryId"
+  | "loanLentInitialCategoryId"
+  | "loanLentPrincipalCategoryId"
+  | "loanLentInterestCategoryId"
+  | "loanLentPrepayFeeCategoryId"
+  | "openTimelineUrl"
+>>;
+```
+
+- [ ] **Step 3: Verify TypeScript and lint**
+
+```bash
+pnpm exec tsc --noEmit && pnpm exec eslint lib/api/settings.ts app/api/settings/route.ts
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/api/settings/route.ts lib/api/settings.ts
+git commit -m "feat: expose openTimelineUrl in settings API"
+```
+
+---
+
+### Task 3: OpenTimeline proxy API routes
+
+**Files:**
+- Create: `app/api/integrations/opentimeline/visits/route.ts`
+- Create: `app/api/integrations/opentimeline/places/route.ts`
+
+**Interfaces:**
+- Consumes: `UserSettings.openTimelineUrl` (read from DB); `getSession` from `@/app/lib/auth`; `prisma` from `@/app/lib/db`
+- Produces:
+  - `GET /api/integrations/opentimeline/visits?at=<ISO>` → `{ placeId: string; placeName: string } | null`
+  - `GET /api/integrations/opentimeline/places?q=<string>` → `{ places: { id: string; name: string }[] }`
+
+- [ ] **Step 1: Create directory**
+
+```bash
+mkdir -p /Users/haitran/code/wealth-manager/app/api/integrations/opentimeline/visits
+mkdir -p /Users/haitran/code/wealth-manager/app/api/integrations/opentimeline/places
+```
+
+- [ ] **Step 2: Create `app/api/integrations/opentimeline/visits/route.ts`**
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/app/lib/db";
+import { getSession } from "@/app/lib/auth";
+
+export async function GET(req: NextRequest) {
+  const session = await getSession(req);
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const at = req.nextUrl.searchParams.get("at");
+  if (!at) return NextResponse.json({ error: "at parameter required" }, { status: 400 });
+
+  const settings = await prisma.userSettings.findUnique({ where: { userId: session.userId } });
+  if (!settings?.openTimelineUrl) {
+    return NextResponse.json(null);
+  }
+
+  const atDate = new Date(at);
+  if (isNaN(atDate.getTime())) {
+    return NextResponse.json({ error: "Invalid at parameter" }, { status: 400 });
+  }
+
+  // Query the full day so partial-day visits are included
+  const dayStart = new Date(atDate);
+  dayStart.setUTCHours(0, 0, 0, 0);
+  const dayEnd = new Date(atDate);
+  dayEnd.setUTCHours(23, 59, 59, 999);
+
+  try {
+    const url = new URL("/api/visits", settings.openTimelineUrl);
+    url.searchParams.set("start", dayStart.toISOString());
+    url.searchParams.set("end", dayEnd.toISOString());
+    url.searchParams.set("status", "confirmed");
+
+    const res = await fetch(url.toString(), { signal: AbortSignal.timeout(5000) });
+    if (!res.ok) return NextResponse.json(null);
+
+    const visits: { placeId: number; place?: { id: number; name: string } }[] = await res.json();
+    if (!visits.length) return NextResponse.json(null);
+
+    const first = visits[0];
+    const placeId = String(first.placeId ?? first.place?.id);
+    const placeName = first.place?.name ?? "";
+    if (!placeId || !placeName) return NextResponse.json(null);
+
+    return NextResponse.json({ placeId, placeName });
+  } catch {
+    return NextResponse.json(null);
+  }
+}
+```
+
+- [ ] **Step 3: Create `app/api/integrations/opentimeline/places/route.ts`**
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/app/lib/db";
+import { getSession } from "@/app/lib/auth";
+
+export async function GET(req: NextRequest) {
+  const session = await getSession(req);
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const q = req.nextUrl.searchParams.get("q")?.trim();
+  if (!q) return NextResponse.json({ places: [] });
+
+  const settings = await prisma.userSettings.findUnique({ where: { userId: session.userId } });
+  if (!settings?.openTimelineUrl) {
+    return NextResponse.json({ places: [] });
+  }
+
+  try {
+    const url = new URL("/api/places", settings.openTimelineUrl);
+    url.searchParams.set("q", q);
+    url.searchParams.set("limit", "10");
+
+    const res = await fetch(url.toString(), { signal: AbortSignal.timeout(5000) });
+    if (!res.ok) return NextResponse.json({ places: [] });
+
+    const raw: { id: number; name: string }[] = await res.json();
+    const places = raw.map((p) => ({ id: String(p.id), name: p.name }));
+    return NextResponse.json({ places });
+  } catch {
+    return NextResponse.json({ places: [] });
+  }
+}
+```
+
+- [ ] **Step 4: Verify TypeScript and lint**
+
+```bash
+pnpm exec tsc --noEmit && pnpm exec eslint app/api/integrations/
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/integrations/
+git commit -m "feat: add OpenTimeline proxy API routes for visits and places"
+```
+
+---
+
+### Task 4: Client-side OpenTimeline API lib
+
+**Files:**
+- Create: `lib/api/opentimeline.ts`
+
+**Interfaces:**
+- Consumes: `api` (axios) from `@/lib/axios`; proxy routes from Task 3
+- Produces:
+  - `getVisitSuggestion(date: string): Promise<{ placeId: string; placeName: string } | null>`
+  - `searchPlaces(q: string): Promise<{ id: string; name: string }[]>`
+
+- [ ] **Step 1: Create `lib/api/opentimeline.ts`**
+
+```typescript
+import api from "@/lib/axios";
+
+export interface OpenTimelinePlace {
+  id: string;
+  name: string;
+}
+
+export async function getVisitSuggestion(date: string): Promise<OpenTimelinePlace | null> {
+  const { data } = await api.get<OpenTimelinePlace | null>(
+    "/integrations/opentimeline/visits",
+    { params: { at: date } }
+  );
+  return data;
+}
+
+export async function searchPlaces(q: string): Promise<OpenTimelinePlace[]> {
+  const { data } = await api.get<{ places: OpenTimelinePlace[] }>(
+    "/integrations/opentimeline/places",
+    { params: { q } }
+  );
+  return data.places;
+}
+```
+
+- [ ] **Step 2: Verify TypeScript and lint**
+
+```bash
+pnpm exec tsc --noEmit && pnpm exec eslint lib/api/opentimeline.ts
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/api/opentimeline.ts
+git commit -m "feat: add client-side OpenTimeline API lib"
+```
+
+---
+
+### Task 5: OpenTimeline URL setting in settings page
+
+**Files:**
+- Modify: `app/settings/page.tsx`
+
+**Interfaces:**
+- Consumes: `getSettings`, `updateSettings`, `UserSettingsPayload` from `@/lib/api/settings` (updated in Task 2)
+
+- [ ] **Step 1: Add OpenTimeline URL section to settings page**
+
+In `app/settings/page.tsx`, add a new section after the Timezone block (before the `SETTINGS_ITEMS` list block). Add the import for `Link2` icon at the top of the icons import list:
+
+```typescript
+import { ChevronRight, CreditCard, Tag, User, DollarSign, Upload, Landmark, PiggyBank, Building2, HandCoins, Link2 } from "lucide-react";
+```
+
+Then add the section in JSX after the timezone block:
+
+```tsx
+      <div className="rounded-lg border px-4 py-3">
+        <p className="text-sm font-medium mb-0.5 flex items-center gap-2">
+          <Link2 className="size-4" />
+          OpenTimeline
+        </p>
+        <p className="text-xs text-muted-foreground mb-3">
+          Connect your OpenTimeline instance to auto-suggest locations on transactions
+        </p>
+        <input
+          type="url"
+          placeholder="http://localhost:3000"
+          defaultValue={settings?.openTimelineUrl ?? ""}
+          className="w-full rounded-md border bg-background px-3 py-2 text-[16px] md:text-sm"
+          onBlur={(e) => {
+            const val = e.target.value.trim();
+            updateMutation.mutate({ openTimelineUrl: val || null });
+          }}
+        />
+      </div>
+```
+
+- [ ] **Step 2: Verify TypeScript and lint**
+
+```bash
+pnpm exec tsc --noEmit && pnpm exec eslint app/settings/page.tsx
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Manual test — open settings page**
+
+Run `pnpm dev`, navigate to `/settings`. Verify the OpenTimeline section appears with a URL input. Enter a URL, tab away, then reload the page — the URL should persist.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/settings/page.tsx
+git commit -m "feat: add OpenTimeline URL setting to settings page"
+```
+
+---
+
+### Task 6: LocationPicker component
+
+**Files:**
+- Create: `components/transactions/location-picker.tsx`
+
+**Interfaces:**
+- Consumes: `getVisitSuggestion`, `searchPlaces`, `OpenTimelinePlace` from `@/lib/api/opentimeline`; `useQuery` from `@tanstack/react-query`; `Input`, `Button`, `Label` from `@/components/ui/`
+- Produces: `LocationPicker` component with props:
+  ```typescript
+  interface LocationPickerProps {
+    date: string;             // YYYY-MM-DD
+    value: OpenTimelinePlace | null;
+    onChange: (value: OpenTimelinePlace | null) => void;
+  }
+  ```
+
+- [ ] **Step 1: Create `components/transactions/location-picker.tsx`**
+
+```typescript
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { MapPin, X, Search } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { getVisitSuggestion, searchPlaces, OpenTimelinePlace } from "@/lib/api/opentimeline";
+import { getSettings } from "@/lib/api/settings";
+
+interface LocationPickerProps {
+  date: string;
+  value: OpenTimelinePlace | null;
+  onChange: (value: OpenTimelinePlace | null) => void;
+}
+
+export function LocationPicker({ date, value, onChange }: LocationPickerProps) {
+  // All hooks must be called unconditionally before any early return
+  const { data: settings } = useQuery({ queryKey: ["settings"], queryFn: getSettings });
+  const [dismissed, setDismissed] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [showDropdown, setShowDropdown] = useState(false);
+  const prevDateRef = useRef(date);
+
+  // Reset dismissed state when date changes
+  useEffect(() => {
+    if (prevDateRef.current !== date) {
+      prevDateRef.current = date;
+      setDismissed(false);
+      setSearchQuery("");
+    }
+  }, [date]);
+
+  const { data: suggestion, isLoading: isSuggesting } = useQuery({
+    queryKey: ["opentimeline-visit", date],
+    queryFn: () => getVisitSuggestion(date),
+    enabled: !!date && !value && !dismissed && !!settings?.openTimelineUrl,
+    retry: false,
+    staleTime: 60_000,
+  });
+
+  const { data: searchResults = [] } = useQuery({
+    queryKey: ["opentimeline-places", searchQuery],
+    queryFn: () => searchPlaces(searchQuery),
+    enabled: searchQuery.length >= 2 && !!settings?.openTimelineUrl,
+    retry: false,
+    staleTime: 30_000,
+  });
+
+  // Hidden entirely when OpenTimeline is not configured
+  if (!settings?.openTimelineUrl) return null;
+
+  // Confirmed value — show with clear button
+  if (value) {
+    return (
+      <div className="space-y-2">
+        <Label>Location (optional)</Label>
+        <div className="flex items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm">
+          <MapPin className="size-4 text-muted-foreground shrink-0" />
+          <span className="flex-1 truncate">{value.name}</span>
+          <button
+            type="button"
+            onClick={() => { onChange(null); setDismissed(false); }}
+            className="text-muted-foreground hover:text-foreground"
+            aria-label="Clear location"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Auto-suggestion available
+  if (!dismissed && suggestion) {
+    return (
+      <div className="space-y-2">
+        <Label>Location (optional)</Label>
+        <div className="flex items-center gap-2 rounded-md border border-primary/40 bg-primary/5 px-3 py-2 text-sm">
+          <MapPin className="size-4 text-primary shrink-0" />
+          <span className="flex-1 truncate text-foreground">{suggestion.name}</span>
+          <button
+            type="button"
+            onClick={() => onChange(suggestion)}
+            className="text-xs font-medium text-primary hover:text-primary/80 shrink-0"
+          >
+            Accept
+          </button>
+          <button
+            type="button"
+            onClick={() => setDismissed(true)}
+            className="text-muted-foreground hover:text-foreground"
+            aria-label="Dismiss suggestion"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Suggestion loading
+  if (!dismissed && isSuggesting) {
+    return (
+      <div className="space-y-2">
+        <Label>Location (optional)</Label>
+        <div className="flex items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm text-muted-foreground animate-pulse">
+          <MapPin className="size-4 shrink-0" />
+          <span>Looking up location…</span>
+        </div>
+      </div>
+    );
+  }
+
+  // Manual search
+  return (
+    <div className="space-y-2">
+      <Label>Location (optional)</Label>
+      <div className="relative">
+        <div className="flex items-center rounded-md border border-input bg-background px-3 gap-2">
+          <Search className="size-4 text-muted-foreground shrink-0" />
+          <Input
+            type="text"
+            placeholder="Search location…"
+            value={searchQuery}
+            onChange={(e) => { setSearchQuery(e.target.value); setShowDropdown(true); }}
+            onFocus={() => setShowDropdown(true)}
+            onBlur={() => setTimeout(() => setShowDropdown(false), 150)}
+            className="border-0 shadow-none px-0 text-[16px] md:text-sm focus-visible:ring-0"
+          />
+        </div>
+        {showDropdown && searchResults.length > 0 && (
+          <ul className="absolute z-50 w-full mt-1 rounded-md border bg-popover shadow-md overflow-hidden">
+            {searchResults.map((place) => (
+              <li key={place.id}>
+                <button
+                  type="button"
+                  onMouseDown={() => { onChange(place); setSearchQuery(""); setShowDropdown(false); }}
+                  className="flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-accent text-left"
+                >
+                  <MapPin className="size-4 text-muted-foreground shrink-0" />
+                  {place.name}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify TypeScript and lint**
+
+```bash
+pnpm exec tsc --noEmit && pnpm exec eslint components/transactions/location-picker.tsx
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/transactions/location-picker.tsx
+git commit -m "feat: add LocationPicker component with auto-suggest and manual search"
+```
+
+---
+
+### Task 7: Wire location through Transaction type, form, and page
+
+**Files:**
+- Modify: `lib/api/transactions.ts`
+- Modify: `components/transactions/transaction-form.tsx`
+- Modify: `app/transactions/page.tsx`
+
+**Interfaces:**
+- Consumes: `LocationPicker` from `@/components/transactions/location-picker`; `OpenTimelinePlace` from `@/lib/api/opentimeline`
+- Produces: `Transaction.locationPlaceId: string | null`, `Transaction.locationPlaceName: string | null` in the TypeScript type; updated `createTransaction` / `updateTransaction` payloads; updated form `onSubmit` signature
+
+- [ ] **Step 1: Update `lib/api/transactions.ts` — add location fields to Transaction interface and payloads**
+
+Add to `Transaction` interface (after `details`):
+
+```typescript
+export interface Transaction {
+  id: string;
+  amount: number;
+  date: string;
+  description: string | null;
+  details: string | null;
+  locationPlaceId: string | null;
+  locationPlaceName: string | null;
+  accountId: string;
+  account: { id: string; name: string; currency: Currency };
+  categoryId: string;
+  category: { id: string; name: string; type: CategoryType; icon: string | null };
+  userId: string;
+  createdAt: string;
+  updatedAt: string;
+  loanPaymentPrincipal: { id: string; loanId: string; loan: { id: string; name: string } } | null;
+  loanPaymentInterest: { id: string; loanId: string; loan: { id: string; name: string } } | null;
+  loanPaymentPrepayFee: { id: string; loanId: string; loan: { id: string; name: string } } | null;
+}
+```
+
+Update `createTransaction` payload type:
+
+```typescript
+export async function createTransaction(payload: {
+  amount: number;
+  date: string;
+  description?: string;
+  details?: string;
+  accountId: string;
+  categoryId: string;
+  locationPlaceId?: string | null;
+  locationPlaceName?: string | null;
+}): Promise<Transaction> {
+  const { data } = await api.post<Transaction>("/transactions", payload);
+  return data;
+}
+```
+
+Update `updateTransaction` payload type:
+
+```typescript
+export async function updateTransaction(
+  id: string,
+  payload: {
+    amount: number;
+    date: string;
+    description?: string;
+    details?: string;
+    accountId: string;
+    categoryId: string;
+    locationPlaceId?: string | null;
+    locationPlaceName?: string | null;
+  }
+): Promise<Transaction> {
+  const { data } = await api.put<Transaction>(`/transactions/${id}`, payload);
+  return data;
+}
+```
+
+- [ ] **Step 2: Update backend route `app/api/transactions/route.ts` — include location in SELECT and Prisma query**
+
+In the raw SQL SELECT for search, add location fields after `t.details`:
+
+```sql
+t.id, t.amount, t.date, t.description, t.details,
+t."locationPlaceId", t."locationPlaceName",
+t."accountId", ...
+```
+
+In the `prisma.transaction.findMany` select (non-search path), the fields are returned automatically since they're on the model. No change needed there.
+
+In the `POST` handler, extract and persist location fields from request body. Find the POST handler body extraction and add:
+
+```typescript
+const { amount, date, description, details, accountId, categoryId, locationPlaceId, locationPlaceName } = await req.json();
+```
+
+And in `prisma.transaction.create`:
+
+```typescript
+data: {
+  amount: parseFloat(amount),
+  date: parseDateParam(date, session.timezone),
+  description: description?.trim() || null,
+  details: details?.trim() || null,
+  locationPlaceId: locationPlaceId?.trim() || null,
+  locationPlaceName: locationPlaceName?.trim() || null,
+  accountId,
+  categoryId,
+  userId: session.userId,
+},
+```
+
+- [ ] **Step 3: Update backend route `app/api/transactions/[id]/route.ts` — persist location on update**
+
+In the PUT handler, extract location fields:
+
+```typescript
+const { amount, date, description, details, accountId, categoryId, locationPlaceId, locationPlaceName } = await req.json();
+```
+
+And in `prisma.transaction.update`:
+
+```typescript
+data: {
+  amount: parseFloat(amount),
+  date: parseDateParam(date, session.timezone),
+  description: description?.trim() || null,
+  details: details?.trim() || null,
+  locationPlaceId: locationPlaceId?.trim() || null,
+  locationPlaceName: locationPlaceName?.trim() || null,
+  accountId,
+  categoryId,
+},
+```
+
+- [ ] **Step 4: Update `components/transactions/transaction-form.tsx` — add LocationPicker**
+
+Add imports at the top:
+
+```typescript
+import { useState, useEffect, FormEvent } from "react";
+import { LocationPicker } from "@/components/transactions/location-picker";
+import { OpenTimelinePlace } from "@/lib/api/opentimeline";
+```
+
+Update `TransactionFieldsProps` to include location:
+
+```typescript
+interface TransactionFieldsProps {
+  transaction?: Transaction | null;
+  accounts: Account[];
+  categories: TransactionCategory[];
+  defaultDate: string;
+  defaultAccountId: string;
+  error: string;
+  selectedCategoryId: string;
+  onCategoryChange: (id: string) => void;
+  location: OpenTimelinePlace | null;
+  onLocationChange: (value: OpenTimelinePlace | null) => void;
+}
+```
+
+Inside `TransactionFields`, add the `location` and `onLocationChange` destructure, and render `LocationPicker` after the Details field:
+
+```typescript
+function TransactionFields({
+  transaction,
+  accounts,
+  categories,
+  defaultDate,
+  defaultAccountId,
+  error,
+  selectedCategoryId,
+  onCategoryChange,
+  location,
+  onLocationChange,
+}: TransactionFieldsProps) {
+  const [date, setDate] = useState(defaultDate);
+  // ... existing shiftDate function unchanged ...
+
+  return (
+    <div className="space-y-4 py-2">
+      {/* ... all existing fields unchanged ... */}
+
+      {/* Add after the Details textarea block: */}
+      <LocationPicker
+        date={date}
+        value={location}
+        onChange={onLocationChange}
+      />
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+    </div>
+  );
+}
+```
+
+Update `TransactionFormProps.onSubmit` to include location:
+
+```typescript
+onSubmit: (data: {
+  amount: number;
+  date: string;
+  description?: string;
+  details?: string;
+  accountId: string;
+  categoryId: string;
+  locationPlaceId?: string | null;
+  locationPlaceName?: string | null;
+}) => Promise<void>;
+```
+
+In `TransactionForm`, add location state and wire it through:
+
+```typescript
+export function TransactionForm({ open, transaction, accounts, categories, onClose, onSubmit, onDelete }: TransactionFormProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [selectedCategoryId, setSelectedCategoryId] = useState(transaction?.categoryId ?? "");
+  const [location, setLocation] = useState<OpenTimelinePlace | null>(
+    transaction?.locationPlaceId && transaction?.locationPlaceName
+      ? { id: transaction.locationPlaceId, name: transaction.locationPlaceName }
+      : null
+  );
+
+  useEffect(() => {
+    setSelectedCategoryId(transaction?.categoryId ?? "");
+    setLocation(
+      transaction?.locationPlaceId && transaction?.locationPlaceName
+        ? { id: transaction.locationPlaceId, name: transaction.locationPlaceName }
+        : null
+    );
+  }, [transaction?.id, transaction?.categoryId, transaction?.locationPlaceId]);
+```
+
+In `handleSubmit`, add location to the `onSubmit` call:
+
+```typescript
+await onSubmit({
+  amount,
+  date: localDayToISO(date),
+  description: description || undefined,
+  details: details || undefined,
+  accountId,
+  categoryId,
+  locationPlaceId: location?.id ?? null,
+  locationPlaceName: location?.name ?? null,
+});
+```
+
+Pass `location` and `onLocationChange` to `TransactionFields`:
+
+```tsx
+<TransactionFields
+  key={transaction?.id ?? "new"}
+  transaction={transaction}
+  accounts={accounts}
+  categories={categories}
+  defaultDate={defaultDate}
+  defaultAccountId={defaultAccount?.id ?? ""}
+  error={error}
+  selectedCategoryId={selectedCategoryId}
+  onCategoryChange={setSelectedCategoryId}
+  location={location}
+  onLocationChange={setLocation}
+/>
+```
+
+- [ ] **Step 5: Update `app/transactions/page.tsx` — pass location through mutations**
+
+Update the `updateMutation` inline type:
+
+```typescript
+const updateMutation = useMutation({
+  mutationFn: ({
+    id,
+    ...payload
+  }: {
+    id: string;
+    amount: number;
+    date: string;
+    description?: string;
+    details?: string;
+    accountId: string;
+    categoryId: string;
+    locationPlaceId?: string | null;
+    locationPlaceName?: string | null;
+  }) => updateTransaction(id, payload),
+  onSuccess: invalidate,
+});
+```
+
+Update `handleSubmit` type:
+
+```typescript
+async function handleSubmit(payload: {
+  amount: number;
+  date: string;
+  description?: string;
+  details?: string;
+  accountId: string;
+  categoryId: string;
+  locationPlaceId?: string | null;
+  locationPlaceName?: string | null;
+}) {
+  if (editingTransaction) {
+    await updateMutation.mutateAsync({ id: editingTransaction.id, ...payload });
+  } else {
+    await createMutation.mutateAsync(payload);
+  }
+}
+```
+
+- [ ] **Step 6: Verify TypeScript and lint**
+
+```bash
+pnpm exec tsc --noEmit && pnpm exec eslint lib/api/transactions.ts components/transactions/transaction-form.tsx app/transactions/page.tsx app/api/transactions/route.ts "app/api/transactions/[id]/route.ts"
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Manual test — add and edit a transaction with location**
+
+Run `pnpm dev`. Open the Add Transaction dialog. Verify:
+- If OpenTimeline is not configured: location field shows search input (no auto-suggest)
+- If OpenTimeline is configured with a URL: location auto-suggests on load
+- Accepting a suggestion sets it; clearing it shows search input
+- Manually searching and picking a place saves correctly
+- Editing an existing transaction pre-fills the location
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/api/transactions.ts components/transactions/transaction-form.tsx app/transactions/page.tsx app/api/transactions/route.ts "app/api/transactions/[id]/route.ts"
+git commit -m "feat: wire location through transaction types, form, and API routes"
+```
+
+---
+
+### Task 8: Display location in transaction list and detail
+
+**Files:**
+- Modify: `components/transactions/transaction-row.tsx`
+- Modify: `components/transactions/transaction-detail.tsx`
+
+**Interfaces:**
+- Consumes: `Transaction.locationPlaceName` from updated type in Task 7
+
+- [ ] **Step 1: Update `components/transactions/transaction-row.tsx` — show locationPlaceName**
+
+Add `MapPin` to the lucide import:
+
+```typescript
+import { Landmark, MapPin } from "lucide-react";
+```
+
+In the row JSX, after the description/category-name `<p>`, add location display inside the same `<div className="min-w-0">`:
+
+```tsx
+<div className="min-w-0">
+  <div className="flex items-center gap-2">
+    <p className="font-medium text-sm truncate">
+      {transaction.description || transaction.category.name}
+    </p>
+  </div>
+  {transaction.locationPlaceName && (
+    <p className="text-xs text-muted-foreground flex items-center gap-1 truncate mt-0.5">
+      <MapPin className="size-3 shrink-0" />
+      {transaction.locationPlaceName}
+    </p>
+  )}
+  {/* existing loan payment display unchanged */}
+</div>
+```
+
+- [ ] **Step 2: Update `components/transactions/transaction-detail.tsx` — show locationPlaceName**
+
+Add `MapPin` to the lucide import at the top of the file.
+
+In the detail view JSX, find where `details` is displayed and add location after it. The exact location depends on the detail component's structure — add it as a row in the info grid with the same pattern as other fields:
+
+```tsx
+{tx.locationPlaceName && (
+  <div className="flex items-start gap-2 text-sm">
+    <MapPin className="size-4 text-muted-foreground mt-0.5 shrink-0" />
+    <span>{tx.locationPlaceName}</span>
+  </div>
+)}
+```
+
+- [ ] **Step 3: Verify TypeScript and lint**
+
+```bash
+pnpm exec tsc --noEmit && pnpm exec eslint components/transactions/transaction-row.tsx components/transactions/transaction-detail.tsx
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Manual test — verify location appears in list and detail**
+
+Run `pnpm dev`. Create a transaction with a location. Verify:
+- Location name appears as a secondary line under the description in the transaction list
+- Location name appears in the transaction detail view
+- Transactions without a location are unaffected
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/transactions/transaction-row.tsx components/transactions/transaction-detail.tsx
+git commit -m "feat: display location in transaction list and detail views"
+```

--- a/docs/superpowers/specs/2026-06-29-transaction-location-opentimeline-design.md
+++ b/docs/superpowers/specs/2026-06-29-transaction-location-opentimeline-design.md
@@ -1,0 +1,94 @@
+# Transaction Location via OpenTimeline Integration
+
+**Date:** 2026-06-29  
+**Status:** Approved
+
+## Overview
+
+Add optional location support to transactions by integrating with OpenTimeline — a self-hosted GPS timeline service. When a user adds or edits a transaction, wealth-manager auto-suggests the place they were at based on the transaction's date/time. Users can also manually search OpenTimeline places as a fallback.
+
+## Architecture
+
+Wealth-manager adds a backend proxy layer that reads the OpenTimeline URL from the user's settings and forwards requests server-side. The frontend never calls OpenTimeline directly.
+
+```
+Transaction Form
+  → (on date change) GET /api/integrations/opentimeline/visits?at=<ISO>
+      → UserSettings.openTimelineUrl → OpenTimeline GET /api/visits
+  → (manual search)  GET /api/integrations/opentimeline/places?q=<term>
+      → UserSettings.openTimelineUrl → OpenTimeline GET /api/places?q=<term>
+```
+
+If `openTimelineUrl` is not configured, the location field is hidden entirely — no broken UI.
+
+## Data Model
+
+### `UserSettings` — add OpenTimeline URL
+
+```prisma
+model UserSettings {
+  // ...existing fields...
+  openTimelineUrl  String?   // e.g. "http://localhost:3000"
+}
+```
+
+### `Transaction` — add location reference
+
+```prisma
+model Transaction {
+  // ...existing fields...
+  locationPlaceId    String?   // OpenTimeline place ID
+  locationPlaceName  String?   // Denormalized name for display without a live query
+}
+```
+
+`locationPlaceName` is stored alongside the ID so the transaction list and detail views can display the place name without hitting OpenTimeline on every render.
+
+## API Routes
+
+Both routes are authenticated via the existing session auth.
+
+### `GET /api/integrations/opentimeline/visits?at=<ISO>`
+
+- Reads `openTimelineUrl` from the current user's settings
+- Calls `GET <openTimelineUrl>/api/visits?start=<at>&end=<at+1min>&status=confirmed`
+- Returns `{ placeId, placeName }` for the first matching visit, or `null` if none found
+- Returns `503` if `openTimelineUrl` is not configured
+
+### `GET /api/integrations/opentimeline/places?q=<term>`
+
+- Reads `openTimelineUrl` from the current user's settings
+- Calls `GET <openTimelineUrl>/api/places?q=<term>`
+- Returns `{ places: [{ id, name }] }`
+- Returns `503` if `openTimelineUrl` is not configured
+
+## Settings UI
+
+Add an **Integrations** section to the existing settings area (`/app/settings/`). It contains a single field: **OpenTimeline URL** (text input, e.g. `http://localhost:3000`). Saved to `UserSettings.openTimelineUrl`.
+
+## Transaction Form UX
+
+A new optional **Location** field is added between Details and the save button.
+
+### Auto-suggest flow
+
+1. On form mount (or when date changes), query `/api/integrations/opentimeline/visits?at=<date>`
+2. If a place is returned, show a suggested pill: place name with Accept / Clear actions
+3. Accept locks in the place; Clear falls through to the manual search state
+
+### Manual search fallback
+
+- If no suggestion found, or after clearing, show a `Search location...` text input
+- Debounced query to `/api/integrations/opentimeline/places?q=<term>` as the user types
+- Dropdown of matching places to select from
+
+### Display in list/detail views
+
+Show `locationPlaceName` as a small secondary line under the description — no live query needed.
+
+## Out of Scope
+
+- Syncing or caching OpenTimeline data locally
+- Creating new OpenTimeline places from within wealth-manager
+- Showing a map or coordinates in the UI
+- Authentication/API key support for OpenTimeline (plain URL only for now)

--- a/lib/api/opentimeline.ts
+++ b/lib/api/opentimeline.ts
@@ -5,13 +5,12 @@ export interface OpenTimelinePlace {
   name: string;
 }
 
-export async function getVisitSuggestion(date: string): Promise<OpenTimelinePlace | null> {
-  const { data } = await api.get<{ placeId: string; placeName: string } | null>(
+export async function getVisitSuggestions(date: string): Promise<OpenTimelinePlace[]> {
+  const { data } = await api.get<{ places: OpenTimelinePlace[] }>(
     "/integrations/opentimeline/visits",
     { params: { at: date } }
   );
-  if (!data) return null;
-  return { id: data.placeId, name: data.placeName };
+  return data.places;
 }
 
 export async function searchPlaces(q: string): Promise<OpenTimelinePlace[]> {

--- a/lib/api/opentimeline.ts
+++ b/lib/api/opentimeline.ts
@@ -1,0 +1,23 @@
+import api from "@/lib/axios";
+
+export interface OpenTimelinePlace {
+  id: string;
+  name: string;
+}
+
+export async function getVisitSuggestion(date: string): Promise<OpenTimelinePlace | null> {
+  const { data } = await api.get<{ placeId: string; placeName: string } | null>(
+    "/integrations/opentimeline/visits",
+    { params: { at: date } }
+  );
+  if (!data) return null;
+  return { id: data.placeId, name: data.placeName };
+}
+
+export async function searchPlaces(q: string): Promise<OpenTimelinePlace[]> {
+  const { data } = await api.get<{ places: OpenTimelinePlace[] }>(
+    "/integrations/opentimeline/places",
+    { params: { q } }
+  );
+  return data.places;
+}

--- a/lib/api/settings.ts
+++ b/lib/api/settings.ts
@@ -14,6 +14,7 @@ export interface UserSettings {
   loanLentPrincipalCategoryId: string | null;
   loanLentInterestCategoryId: string | null;
   loanLentPrepayFeeCategoryId: string | null;
+  openTimelineUrl: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -30,6 +31,7 @@ export type UserSettingsPayload = Partial<Pick<
   | "loanLentPrincipalCategoryId"
   | "loanLentInterestCategoryId"
   | "loanLentPrepayFeeCategoryId"
+  | "openTimelineUrl"
 >>;
 
 export async function getSettings(): Promise<UserSettings> {

--- a/lib/api/transactions.ts
+++ b/lib/api/transactions.ts
@@ -10,6 +10,8 @@ export interface Transaction {
   date: string;
   description: string | null;
   details: string | null;
+  locationPlaceId: string | null;
+  locationPlaceName: string | null;
   accountId: string;
   account: { id: string; name: string; currency: Currency };
   categoryId: string;
@@ -49,6 +51,8 @@ export async function createTransaction(payload: {
   details?: string;
   accountId: string;
   categoryId: string;
+  locationPlaceId?: string | null;
+  locationPlaceName?: string | null;
 }): Promise<Transaction> {
   const { data } = await api.post<Transaction>("/transactions", payload);
   return data;
@@ -63,6 +67,8 @@ export async function updateTransaction(
     details?: string;
     accountId: string;
     categoryId: string;
+    locationPlaceId?: string | null;
+    locationPlaceName?: string | null;
   }
 ): Promise<Transaction> {
   const { data } = await api.put<Transaction>(`/transactions/${id}`, payload);

--- a/prisma/migrations/20260630000000_add_location_to_transactions/migration.sql
+++ b/prisma/migrations/20260630000000_add_location_to_transactions/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "Transaction" ADD COLUMN "locationPlaceId" TEXT,
+ADD COLUMN "locationPlaceName" TEXT;
+
+-- AlterTable
+ALTER TABLE "UserSettings" ADD COLUMN "openTimelineUrl" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,7 @@ model UserSettings {
   loanLentPrincipalCategoryId     String?
   loanLentInterestCategoryId      String?
   loanLentPrepayFeeCategoryId     String?
+  openTimelineUrl                 String?
   createdAt                       DateTime @default(now())
   updatedAt                       DateTime @updatedAt
 }
@@ -114,6 +115,8 @@ model Transaction {
   loanInitial          Loan?               @relation("LoanInitialTransaction")
   assetPurchase        Asset?              @relation("AssetPurchaseTransaction")
   assetSell            Asset?              @relation("AssetSellTransaction")
+  locationPlaceId      String?
+  locationPlaceName    String?
   createdAt            DateTime            @default(now())
   updatedAt            DateTime            @updatedAt
 }


### PR DESCRIPTION
## Summary

Adds optional **location** to transactions by integrating with a self-hosted [OpenTimeline](https://github.com/) instance. When adding or editing a transaction, the form surfaces the places you visited on that date (pulled from OpenTimeline visits) as clickable pills, with manual place search as a fallback.

## How it works

- A new **OpenTimeline URL** setting (per user) enables the integration. When unset, the location UI is hidden entirely.
- Wealth-manager proxies OpenTimeline requests **server-side** (avoids CORS, keeps the endpoint off the client):
  - `GET /api/integrations/opentimeline/visits?at=<ISO>` → all distinct places visited that day
  - `GET /api/integrations/opentimeline/places?q=<term>` → place search
- Location is stored on the transaction as `locationPlaceId` + denormalized `locationPlaceName`, so list/detail views render it without a live query.

## UX

- The day's visited places show as selectable pills — nothing is auto-selected; click a pill to set it.
- Manual search box below covers places not in that day's visits.
- Location displays as a secondary line in the transaction list and a row in the detail view.

## Changes

- **DB:** `Transaction.locationPlaceId` / `locationPlaceName`, `UserSettings.openTimelineUrl` (migration included)
- **API:** settings expose `openTimelineUrl`; two OpenTimeline proxy routes; transaction create/update persist location
- **UI:** `LocationPicker` component, settings page field, form wiring, list/detail display
- **Fix:** transaction form now resets all state each time the dialog opens (previously persisted prior state on reopen)

## Testing

- `tsc --noEmit` clean
- `next build` compiles; new routes registered
- `vitest` — 40/40 pass

## Notes

- Spec: `docs/superpowers/specs/2026-06-29-transaction-location-opentimeline-design.md`
- Plan: `docs/superpowers/plans/2026-06-29-transaction-location-opentimeline.md`
- Pre-existing schema drift observed (`Asset.purchaseTransactionId` required in schema but nullable in DB with a NULL row) — **not addressed here**; the migration was applied via `prisma migrate deploy` to avoid touching unrelated asset data.
